### PR TITLE
chore(scoring): align measure doc scoring with new TMDL doc blocks

### DIFF
--- a/tools/measure_description_audit.py
+++ b/tools/measure_description_audit.py
@@ -1,7 +1,7 @@
 # measure_description_audit.py
 # Generates a summary audit of measure descriptions across TMDL models.
-# Scoring rubric (1-5) based on presence of five components:
-# Purpose, Calculation Logic, Dependencies, Dynamic Behavior, Format/Type.
+# Scoring rubric (1-5) based on presence of four doc block components:
+# Purpose, Calculation Logic, Dynamic Behavior, Format/Type.
 
 import os
 import re
@@ -10,65 +10,15 @@ import argparse
 from typing import List, Tuple, Optional, Dict
 
 MEASURE_RE = re.compile(r"^\s*measure\s+(.+?)\s*(?:=|$)")
-DESC_RE = re.compile(r"^\s*description:\s*(.*)$")
+DOC_RE = re.compile(r"^\s*///\s*(Purpose|Calculation Logic|Dynamic Behavior|Format/Type):\s*(.*)$", re.I)
 PLACEHOLDER_RE = re.compile(r"^(?:todo|tbd|n/?a|na|none|description|add description|placeholder|fixme|-)\b", re.I)
 
-# DAX patterns for dependency extraction
-COLUMN_REF_RE = re.compile(r"([A-Za-z0-9_]+)\[([A-Za-z0-9_]+)\]")
-MEASURE_REF_RE = re.compile(r"\[([A-Za-z0-9_.]+)\]")
+# Generic phrases that should not be treated as meaningful doc content.
+GENERIC_PURPOSE = re.compile(r"compute the measure result from the dax expression and current filter context", re.I)
+GENERIC_CALC = re.compile(r"(?:see|refer to) dax expression", re.I)
+GENERIC_DYNAMIC = re.compile(r"(?:see|refer to) dax expression", re.I)
 
-# DAX behavior indicators
-BEHAVIOR_FUNCS = {
-    "calculate",
-    "calculatetable",
-    "filter",
-    "all",
-    "allexcept",
-    "allselected",
-    "keepfilters",
-    "removefilters",
-    "treatas",
-    "userelationship",
-    "crossfilter",
-    "summarize",
-    "summarizecolumns",
-    "addcolumns",
-    "values",
-}
-
-# DAX logic indicators
-LOGIC_FUNCS = {
-    "sum",
-    "average",
-    "distinctcount",
-    "count",
-    "countrows",
-    "min",
-    "max",
-    "divide",
-    "if",
-    "switch",
-    "round",
-    "roundup",
-    "rounddown",
-    "format",
-}
-
-# Format indicators for description text
-FORMAT_HINTS = {
-    "format",
-    "number",
-    "percent",
-    "percentage",
-    "currency",
-    "date",
-    "datetime",
-    "text",
-    "string",
-}
-
-
-def parse_desc_value(raw: str) -> str:
+def parse_doc_value(raw: str) -> str:
     raw = raw.strip()
     if not raw:
         return ""
@@ -86,7 +36,7 @@ def is_placeholder(text: str) -> bool:
     return bool(PLACEHOLDER_RE.match(text.strip()))
 
 
-def parse_tmdl(path: str) -> List[Tuple[str, str, Optional[str], Optional[str]]]:
+def parse_tmdl(path: str) -> List[Tuple[str, Dict[str, str], Optional[str]]]:
     with open(path, "r", encoding="utf-8") as f:
         lines = f.readlines()
 
@@ -101,23 +51,25 @@ def parse_tmdl(path: str) -> List[Tuple[str, str, Optional[str], Optional[str]]]
         if (name.startswith("'") and name.endswith("'")) or (name.startswith('"') and name.endswith('"')):
             name = name[1:-1]
 
-        # expression
-        expr = ""
-        if "```" in lines[i]:
-            i += 1
-            expr_lines = []
-            while i < len(lines) and lines[i].strip() != "```":
-                expr_lines.append(lines[i].rstrip("\r\n"))
-                i += 1
-            expr = "\n".join(expr_lines).strip()
-        else:
-            if "=" in lines[i]:
-                expr = lines[i].split("=", 1)[1].strip()
+        # doc block immediately above measure
+        docs: Dict[str, str] = {}
+        if i > 0 and lines[i - 1].lstrip().startswith("///"):
+            j = i - 1
+            doc_lines = []
+            while j >= 0 and lines[j].lstrip().startswith("///"):
+                doc_lines.append(lines[j].rstrip("\r\n"))
+                j -= 1
+            for line in reversed(doc_lines):
+                d = DOC_RE.match(line)
+                if not d:
+                    continue
+                key = d.group(1).strip().lower()
+                value = parse_doc_value(d.group(2))
+                docs[key] = value
 
-        # search description within block
+        # search formatString within block
         start_indent = len(lines[i]) - len(lines[i].lstrip())
         j = i + 1
-        desc = None
         fmt = None
         while j < len(lines):
             if lines[j].strip() == "":
@@ -126,65 +78,80 @@ def parse_tmdl(path: str) -> List[Tuple[str, str, Optional[str], Optional[str]]]
             indent = len(lines[j]) - len(lines[j].lstrip())
             if indent <= start_indent:
                 break
-            d = DESC_RE.match(lines[j])
-            if d:
-                desc = parse_desc_value(d.group(1))
             if lines[j].lstrip().startswith("formatString:"):
                 fmt = lines[j].split("formatString:", 1)[1].strip().strip('"')
             j += 1
 
-        measures.append((name, expr, desc, fmt))
+        measures.append((name, docs, fmt))
         i = j
 
     return measures
 
 
-def extract_dependencies(expr: str) -> Tuple[List[str], List[str]]:
-    cols = [f"{t}[{c}]" for t, c in COLUMN_REF_RE.findall(expr or "")]
-    # measure refs are any [name] that are not column refs
-    all_brackets = MEASURE_REF_RE.findall(expr or "")
-    # strip column refs from measure refs
-    col_names = {c for _, c in COLUMN_REF_RE.findall(expr or "")}
-    measures = [m for m in all_brackets if m not in col_names]
-    return sorted(set(cols)), sorted(set(measures))
+def is_nontrivial(text: str, field: str) -> bool:
+    if not text or is_placeholder(text):
+        return False
+    text_lc = text.lower().strip()
+    if field == "purpose":
+        if GENERIC_PURPOSE.search(text_lc):
+            return False
+        return len(text_lc) >= 8
+    if field == "calculation logic":
+        if GENERIC_CALC.search(text_lc):
+            return False
+        return len(text_lc) >= 8
+    if field == "dynamic behavior":
+        if GENERIC_DYNAMIC.search(text_lc):
+            return False
+        return "filter context" in text_lc or "filters" in text_lc or "slicer" in text_lc or len(text_lc) >= 8
+    if field == "format/type":
+        return len(text_lc) > 0 and text_lc not in {"not specified", "n/a", "na", "none"}
+    return False
 
 
-def describe_components(expr: str, desc: Optional[str], fmt: Optional[str]) -> Dict[str, bool]:
-    desc_text = (desc or "").lower()
-    expr_text = (expr or "").lower()
+def describe_components(docs: Dict[str, str], fmt: Optional[str]) -> Dict[str, bool]:
+    purpose_text = docs.get("purpose", "")
+    calc_text = docs.get("calculation logic", "")
+    dynamic_text = docs.get("dynamic behavior", "")
+    format_text = docs.get("format/type", "")
 
-    purpose = any(k in desc_text for k in ["purpose", "goal", "aim", "compute", "calculate", "measure", "rate", "ratio", "count", "sum", "average", "score", "total"])
-    logic = any(k in desc_text for k in ["logic", "formula", "divide", "sum", "average", "count", "distinct", "ratio", "round", "if", "switch"]) or any(f"{fn}(" in expr_text for fn in LOGIC_FUNCS)
-    deps = bool(re.search(r"\w+\[\w+\]", desc or "")) or bool(COLUMN_REF_RE.search(expr or "")) or bool(MEASURE_REF_RE.search(expr or ""))
-    behavior = any(k in desc_text for k in ["filter", "context", "dynamic", "calculate", "calculated", "depends on selection"]) or any(f"{fn}(" in expr_text for fn in BEHAVIOR_FUNCS)
-    fmt_present = bool(fmt) or any(k in desc_text for k in FORMAT_HINTS)
+    purpose = is_nontrivial(purpose_text, "purpose")
+    logic = is_nontrivial(calc_text, "calculation logic")
+    behavior = is_nontrivial(dynamic_text, "dynamic behavior")
+
+    fmt_present = is_nontrivial(format_text, "format/type")
+    if fmt:
+        fmt_present = fmt_present and format_text == fmt
+    else:
+        fmt_present = fmt_present and format_text == "Unspecified"
 
     return {
         "purpose": purpose,
         "logic": logic,
-        "dependencies": deps,
         "behavior": behavior,
         "format": fmt_present,
     }
 
 
-def score_components(components: Dict[str, bool], desc: Optional[str]) -> Tuple[int, str]:
-    if desc is None or desc.strip() == "" or is_placeholder(desc):
-        return 1, "Missing or placeholder description."
+def score_components(components: Dict[str, bool], docs: Dict[str, str]) -> Tuple[int, str]:
+    if not docs:
+        return 1, "Missing doc block."
 
     present = [k for k, v in components.items() if v]
     missing = [k for k, v in components.items() if not v]
 
-    if len(present) <= 1:
-        return 2, "Description is minimal; missing: " + ", ".join(missing)
+    if len(present) == 0:
+        return 1, "Doc block is empty or generic."
+    if len(present) == 1:
+        return 2, "Doc block is minimal; missing: " + ", ".join(missing)
     if len(present) == 2:
-        return 3, "Partial description; missing: " + ", ".join(missing)
-    if len(present) == 3 or len(present) == 4:
-        return 4, "Good coverage; missing: " + ", ".join(missing)
-    return 5, "Complete description covers all required components."
+        return 3, "Partial doc block; missing: " + ", ".join(missing)
+    if len(present) == 3:
+        return 4, "Good doc block; missing: " + ", ".join(missing)
+    return 5, "Doc block covers all required components."
 
 
-def collect_measures(root: str) -> List[Tuple[str, str, Optional[str], Optional[str]]]:
+def collect_measures(root: str) -> List[Tuple[str, Dict[str, str], Optional[str]]]:
     measures = []
     for dirpath, _, filenames in os.walk(root):
         for fn in filenames:
@@ -208,9 +175,9 @@ def main() -> int:
     rows = []
     score_counts = {i: 0 for i in range(1, 6)}
 
-    for name, expr, desc, fmt in measures:
-        components = describe_components(expr, desc, fmt)
-        score, reason = score_components(components, desc)
+    for name, docs, fmt in measures:
+        components = describe_components(docs, fmt)
+        score, reason = score_components(components, docs)
         score_counts[score] += 1
         rows.append((name, score, reason))
 


### PR DESCRIPTION
• Updates measure_description_audit.py scoring logic to match the standardized 4-line TMDL doc blocks (Purpose, Calculation Logic, Dynamic Behavior, Format/Type).
• Applies to scoring for both semantic models (Sales Performance + ADE) without modifying any PBIP/TMDL artifacts.
• No DAX logic changes.

Checks
• Only audit/scoring code changed
• No .tmdl/.pbip/.pbir/.pbism changes