### PR TITLE
Suppress data state for Top bookmark

### DIFF
--- a/powerbi/src/Tactical Report.Report/definition/bookmarks/7711d55326a51431edd4.bookmark.json
+++ b/powerbi/src/Tactical Report.Report/definition/bookmarks/7711d55326a51431edd4.bookmark.json
@@ -3,7 +3,8 @@
   "displayName": "Top",
   "name": "7711d55326a51431edd4",
   "options": {
-    "targetVisualNames": []
+    "targetVisualNames": [],
+    "suppressData": true
   },
   "explorationState": {
     "version": "1.3",


### PR DESCRIPTION
Disable data state on Top bookmark to prevent hidden date slicer filters from applying.