### PR TITLE
Fix stale Strategy Report field references

### DIFF
--- a/powerbi/Strategy Report.pbix
+++ b/powerbi/Strategy Report.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82bf73d890875faae813cd3abd67045db94c043432690101d21ff1fa810a7592
-size 8545034
+oid sha256:f46cb5b51155f1fb032ecd2b64f0a7cf07f55ad89248dc7a9e4e589169275d5b
+size 8545073

--- a/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/3d6fdd690de7bc4cd479/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/3d6fdd690de7bc4cd479/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/9d2f670b048bd8d088d7/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/9d2f670b048bd8d088d7/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/b899851b30bc64c012c6/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/b899851b30bc64c012c6/visual.json
@@ -270,7 +270,7 @@
                 "Entity": "ssr_history"
               }
             },
-            "Property": "meas.ssr_history_success_rate_combined_post_sales_upselling"
+            "Property": "meas.ssr_history_success_rate_combined_post_sales_existing_customer_selling"
           }
         },
         "type": "Advanced",

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/77d4e021550bcde1ec40/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/77d4e021550bcde1ec40/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/c2d1890b44c4283d32b2/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/c2d1890b44c4283d32b2/visual.json
@@ -268,7 +268,7 @@
                 "Entity": "ssr_history"
               }
             },
-            "Property": "meas.ssr_history_success_rate_combined_post_sales_upselling"
+            "Property": "meas.ssr_history_success_rate_combined_post_sales_existing_customer_selling"
           }
         },
         "type": "Advanced",

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/d8da3405e4d6727783b0/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/d8da3405e4d6727783b0/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/8a164378b7e5302764ac/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/8a164378b7e5302764ac/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/de62adb40e431e67be69/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/de62adb40e431e67be69/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/264cb3d09645dd3b0511/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/264cb3d09645dd3b0511/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/6b43aadb0a4664016582/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/6b43aadb0a4664016582/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/48ca404bb340b7c7d122/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/48ca404bb340b7c7d122/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/a481f485149c8b3661a8/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/a481f485149c8b3661a8/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/a8cf579a90cb80640c59/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/a8cf579a90cb80640c59/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/ff5f0d561a50ac9c5a51/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/ff5f0d561a50ac9c5a51/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/155159364cc744bbbbae/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/155159364cc744bbbbae/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/c1e8f68030d9a3092e92/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/c1e8f68030d9a3092e92/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/8a12d6802e0648231590/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/8a12d6802e0648231590/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/83d48d79dba99ee0770c/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/83d48d79dba99ee0770c/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/e17ef00a02221eee4149/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/e17ef00a02221eee4149/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/8e940fbf596ebfc5deba/visuals/b4c58260dc934e0d5aed/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/8e940fbf596ebfc5deba/visuals/b4c58260dc934e0d5aed/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "ssr"
                     }
                   },
-                  "Property": "trueai_address_country"
+                  "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/9613185c0b5d01cc2e8b/visuals/c6309995b0173b7981b7/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9613185c0b5d01cc2e8b/visuals/c6309995b0173b7981b7/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/5b60c1709a1201e20091/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/5b60c1709a1201e20091/visual.json
@@ -271,7 +271,7 @@
                 "Entity": "ssr_history"
               }
             },
-            "Property": "meas.ssr_history_success_rate_combined_post_sales_upselling"
+            "Property": "meas.ssr_history_success_rate_combined_post_sales_existing_customer_selling"
           }
         },
         "type": "Advanced",

--- a/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/e3bcfd01c3730ac5cc09/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/e3bcfd01c3730ac5cc09/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/f56d710da78544009844/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/f56d710da78544009844/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/52f2e64b038b1b0169e2/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/52f2e64b038b1b0169e2/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/ed465da5ef1753656d3d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/ed465da5ef1753656d3d/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection1252b003407e4ccc57ae/visuals/1b5daf29849d14193fc2/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection1252b003407e4ccc57ae/visuals/1b5daf29849d14193fc2/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/39c24146435a7f9d7a58/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/39c24146435a7f9d7a58/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/423ffe91b2d14dbc7bd3/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/423ffe91b2d14dbc7bd3/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/efa1d025ad151db1ca68/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/efa1d025ad151db1ca68/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/f5001b2279c61c1c772f/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/f5001b2279c61c1c772f/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/d38f178a07635288108e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/d38f178a07635288108e/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/f9164b888a91cc92bf53/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/f9164b888a91cc92bf53/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/1c565421f3fd766bc681/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/1c565421f3fd766bc681/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/93e4f67552a6f453115a/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/93e4f67552a6f453115a/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/733f956273f60858cae6/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/733f956273f60858cae6/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/8b40c6a4da1ab1998cae/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/8b40c6a4da1ab1998cae/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/919850284cb4bdbf88fe/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/919850284cb4bdbf88fe/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/c2c8be208f5505a1838d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/c2c8be208f5505a1838d/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/e2153f66a0bc830fb6bf/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/e2153f66a0bc830fb6bf/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/fd9e02a9d143d14984eb/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/fd9e02a9d143d14984eb/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/b4469fcf62a1680e73c4/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/b4469fcf62a1680e73c4/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/db62dde7bd092684be38/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/db62dde7bd092684be38/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/0c13774dc60e74925852/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/0c13774dc60e74925852/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/5713a032780abe575616/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/5713a032780abe575616/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/0dedade25837b7429f99/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/0dedade25837b7429f99/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/26816d486b7bd3a0c733/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/26816d486b7bd3a0c733/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/67e65d4c1682b17a4a43/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/67e65d4c1682b17a4a43/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/c042912c30988fe1f862/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/c042912c30988fe1f862/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/89ff52af0c1131f868ed/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/89ff52af0c1131f868ed/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/e58b17c2d62a3da1aedc/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/e58b17c2d62a3da1aedc/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/479dca6fa92e216579af/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/479dca6fa92e216579af/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/a9c14c886cff76070c3f/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/a9c14c886cff76070c3f/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/2ab559a4304f765fbf6d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/2ab559a4304f765fbf6d/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/b53a75b8e9ecd430f2d2/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/b53a75b8e9ecd430f2d2/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/729f977ecf1d8784baf2/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/729f977ecf1d8784baf2/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/d0358fba776d379ee012/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/d0358fba776d379ee012/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/3f8ff229c3820c31031e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/3f8ff229c3820c31031e/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/a69e17d446e0442ede43/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/a69e17d446e0442ede43/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/ad6370403d95091ec9bc/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/ad6370403d95091ec9bc/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/ffbf37929909d106eda6/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/ffbf37929909d106eda6/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/419ef180654e4077a043/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/419ef180654e4077a043/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/e1a4697805667aed0052/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/e1a4697805667aed0052/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/ee1b5b947100e5ea19e5/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/ee1b5b947100e5ea19e5/visual.json
@@ -269,7 +269,7 @@
                 "Entity": "ssr_history"
               }
             },
-            "Property": "meas.ssr_history_success_rate_combined_post_sales_upselling"
+            "Property": "meas.ssr_history_success_rate_combined_post_sales_existing_customer_selling"
           }
         },
         "type": "Advanced",

--- a/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/141cef24c7c11f73191c/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/141cef24c7c11f73191c/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/a7f140a4dfbab85bd2f4/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/a7f140a4dfbab85bd2f4/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/66b85aac7957e6204a5e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/66b85aac7957e6204a5e/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/c199d7210484d3d7279e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/c199d7210484d3d7279e/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/10f652c08a4cc0735aa5/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/10f652c08a4cc0735aa5/visual.json
@@ -268,7 +268,7 @@
                 "Entity": "ssr_history"
               }
             },
-            "Property": "meas.ssr_history_success_rate_combined_post_sales_upselling"
+            "Property": "meas.ssr_history_success_rate_combined_post_sales_existing_customer_selling"
           }
         },
         "type": "Advanced",

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/bbadf0df0b4aa1a1ab32/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/bbadf0df0b4aa1a1ab32/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/dc3a8d2a420054e9688d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/dc3a8d2a420054e9688d/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/8c75fcc580170e34a987/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/8c75fcc580170e34a987/visual.json
@@ -268,7 +268,7 @@
                 "Entity": "ssr_history"
               }
             },
-            "Property": "meas.ssr_history_success_rate_combined_post_sales_upselling"
+            "Property": "meas.ssr_history_success_rate_combined_post_sales_existing_customer_selling"
           }
         },
         "type": "Advanced",

--- a/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/d401b442eb17ed2202dc/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/d401b442eb17ed2202dc/visual.json
@@ -26,7 +26,7 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
               "active": true
             }
           ]
@@ -194,7 +194,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country",
+      "groupName": "trueai_addr_country",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/ec736186404edc76b283/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/ec736186404edc76b283/visual.json
@@ -26,8 +26,8 @@
                   "Property": "trueai_addr_country"
                 }
               },
-              "queryRef": "ssr.trueai_address_country",
-              "nativeQueryRef": "trueai_address_country",
+              "queryRef": "ssr.trueai_addr_country",
+              "nativeQueryRef": "trueai_addr_country",
               "active": true
             }
           ]
@@ -401,7 +401,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "trueai_address_country1",
+      "groupName": "trueai_addr_country1",
       "fieldChanges": true,
       "filterChanges": true
     },


### PR DESCRIPTION
## Summary
- Updates Strategy Report visual bindings from the stale `trueai_address_country` reference to `trueai_addr_country`.
- Replaces stale `meas.ssr_history_success_rate_combined_post_sales_upselling` filter references with the existing combined post-sales/existing-customer measure.
- Includes the updated Strategy Report PBIX pointer/content generated by the report changes.

## Why
Power BI embed was failing with `Missing_References` on segmentation visuals because hidden slicers and card filters still pointed at removed or renamed model fields/measures.

## Validation
- Searched Strategy Report page definitions for `trueai_address_country` and `ssr_history_success_rate_combined_post_sales_upselling`; no remaining matches were found.
- Confirmed local branch was created from updated `staging` before committing.