### PR TITLE
Fix Segmentation report visual field references

### DIFF
--- a/powerbi/Strategy Report.pbix
+++ b/powerbi/Strategy Report.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f46cb5b51155f1fb032ecd2b64f0a7cf07f55ad89248dc7a9e4e589169275d5b
-size 8545073
+oid sha256:8805fb67726df553fec9e1bef73b19005ce17dafd60b0bc328296aad1a60a960
+size 8544960

--- a/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/048711b6c47204acb433/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/048711b6c47204acb433/visual.json
@@ -143,7 +143,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -184,7 +184,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -225,7 +225,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/0855e3296a51ae498c1d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/0855e3296a51ae498c1d/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/244cabaa00c894e07305/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/244cabaa00c894e07305/visual.json
@@ -39,10 +39,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "users_history"
+                    "Entity": "cal_end_dates"
                   }
                 },
-                "Property": "trueai_user_role_dept"
+                "Property": "year"
               }
             },
             "direction": "Ascending"

--- a/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/2a18e5b50ee30ce0c37d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/2a18e5b50ee30ce0c37d/visual.json
@@ -143,7 +143,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -184,7 +184,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -225,7 +225,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/685ca8be723a1b669ada/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/685ca8be723a1b669ada/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/77a85fb170610c81e0dc/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/77a85fb170610c81e0dc/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/8b809c49d3c8850594b6/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/8b809c49d3c8850594b6/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/922a7d7ed987670009ee/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/922a7d7ed987670009ee/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/b0917a00b585e5a2c415/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/b0917a00b585e5a2c415/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/b792c7aea820d207abac/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/b792c7aea820d207abac/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/023f2fab0634a9ed2374/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/023f2fab0634a9ed2374/visual.json
@@ -144,7 +144,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -185,7 +185,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -226,7 +226,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/053d8dcaec87b082a255/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/053d8dcaec87b082a255/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/13b962705002ec615b51/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/13b962705002ec615b51/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/3b5aba7d3c1250959cd5/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/3b5aba7d3c1250959cd5/visual.json
@@ -39,10 +39,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "users_history"
+                    "Entity": "cal_end_dates"
                   }
                 },
-                "Property": "trueai_user_role_dept"
+                "Property": "year"
               }
             },
             "direction": "Ascending"

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/4f9ebbc07b0b50be1587/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/4f9ebbc07b0b50be1587/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/5f90ea039095083172e1/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/5f90ea039095083172e1/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/85d16e37461b171bac83/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/85d16e37461b171bac83/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/861d83709121377ed018/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/861d83709121377ed018/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/9c184f3d6912ea38b3e8/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/9c184f3d6912ea38b3e8/visual.json
@@ -144,7 +144,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -185,7 +185,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -226,7 +226,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/9d06146f91c02da08207/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/9d06146f91c02da08207/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/ced4b884c8b220770b3d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/ced4b884c8b220770b3d/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/cf72326d2ed0b0cd3d93/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/cf72326d2ed0b0cd3d93/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/e6a10fd09663795a74ce/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/e6a10fd09663795a74ce/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/fbbfe407356ca1049784/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/fbbfe407356ca1049784/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/237a15baaf2ffc31f597/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/237a15baaf2ffc31f597/visual.json
@@ -162,7 +162,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -203,7 +203,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -244,7 +244,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -962,7 +962,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/533411275c208d0a5742/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/533411275c208d0a5742/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/6381cb2aad725e8a404d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/6381cb2aad725e8a404d/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/7352fabcb5112a7c2271/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/7352fabcb5112a7c2271/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/89da3082da91d493a65b/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/89da3082da91d493a65b/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/a86a90ed11ac64aad4b8/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/a86a90ed11ac64aad4b8/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/a8e2ef2d5b09b175065d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/a8e2ef2d5b09b175065d/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/af209a06ac0403040092/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/af209a06ac0403040092/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/c21ace828da437e42e0d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/c21ace828da437e42e0d/visual.json
@@ -39,10 +39,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "users_history"
+                    "Entity": "cal_end_dates"
                   }
                 },
-                "Property": "trueai_user_role_dept"
+                "Property": "year"
               }
             },
             "direction": "Ascending"

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/c9a8531a55b9d05cf67c/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/c9a8531a55b9d05cf67c/visual.json
@@ -846,7 +846,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/dd36e46152052c11504b/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/dd36e46152052c11504b/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/e394af30b0d2fdb8c137/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/e394af30b0d2fdb8c137/visual.json
@@ -176,7 +176,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -217,7 +217,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -258,7 +258,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -979,7 +979,7 @@
                 "Entity": "quality_buckets"
               }
             },
-            "Property": "col.propensity_min_max_tier_new_logo"
+            "Property": "col.propensity_min_max_tier"
           }
         },
         "type": "Categorical",

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/e3f40996ba607d70b053/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/e3f40996ba607d70b053/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/eb2e0860b2331b8b9d65/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/eb2e0860b2331b8b9d65/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/fb6343217e68038b432b/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/fb6343217e68038b432b/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/05d8ded0a044183037c7/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/05d8ded0a044183037c7/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/186d11ea75e553b54d48/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/186d11ea75e553b54d48/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/2a19a0540990544330ec/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/2a19a0540990544330ec/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/2ab156b81c402b0b4447/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/2ab156b81c402b0b4447/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/3a34c9cc04090ddb6e7e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/3a34c9cc04090ddb6e7e/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/5f5dd0aeca80309b4044/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/5f5dd0aeca80309b4044/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/742c502fc24b700054e0/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/742c502fc24b700054e0/visual.json
@@ -161,7 +161,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -202,7 +202,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -243,7 +243,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/849007b12084e8b9a303/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/849007b12084e8b9a303/visual.json
@@ -176,7 +176,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -217,7 +217,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -258,7 +258,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/a2c7978f7a0e09aa0105/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/a2c7978f7a0e09aa0105/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/b7afa3ea44074c0a43de/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/b7afa3ea44074c0a43de/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/bb5723aaa063a201e2a1/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/bb5723aaa063a201e2a1/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/ce3130ccb30bb8a106a3/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/ce3130ccb30bb8a106a3/visual.json
@@ -39,10 +39,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "users_history"
+                    "Entity": "cal_end_dates"
                   }
                 },
-                "Property": "trueai_user_role_dept"
+                "Property": "year"
               }
             },
             "direction": "Ascending"

--- a/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/e817191243540ddc41a6/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/e817191243540ddc41a6/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/e907cbe751928649830d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/e907cbe751928649830d/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/216ab1f65902c2aa0370/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/216ab1f65902c2aa0370/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/524941a2854b2237aa60/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/524941a2854b2237aa60/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/7c771b68148d61487c15/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/7c771b68148d61487c15/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/9f17c0b6139e1d4a0087/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/9f17c0b6139e1d4a0087/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/a84631454da064a4cd76/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/a84631454da064a4cd76/visual.json
@@ -39,10 +39,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "users_history"
+                    "Entity": "cal_end_dates"
                   }
                 },
-                "Property": "trueai_user_role_dept"
+                "Property": "year"
               }
             },
             "direction": "Ascending"

--- a/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/a983e99a7056ceae6a40/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/a983e99a7056ceae6a40/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/dff372fdc0c75ccd0bdd/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/dff372fdc0c75ccd0bdd/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/f58983d7ac2eb430c4a6/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/f58983d7ac2eb430c4a6/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/05854da61629d060a8da/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/05854da61629d060a8da/visual.json
@@ -161,7 +161,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -202,7 +202,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -243,7 +243,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/1090f4f0080c6536dd15/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/1090f4f0080c6536dd15/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/1e88b4846196859cd991/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/1e88b4846196859cd991/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/20def490e38bd5a86c94/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/20def490e38bd5a86c94/visual.json
@@ -39,10 +39,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "users_history"
+                    "Entity": "cal_end_dates"
                   }
                 },
-                "Property": "trueai_user_role_dept"
+                "Property": "year"
               }
             },
             "direction": "Ascending"

--- a/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/289fe81e00ca7e949097/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/289fe81e00ca7e949097/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/365209e5805d20c80d41/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/365209e5805d20c80d41/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/6eaf50a00238e23dba1e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/6eaf50a00238e23dba1e/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/73ae9ffdaa0da6d1a6c6/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/73ae9ffdaa0da6d1a6c6/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/7414e3bfa909a5340282/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/7414e3bfa909a5340282/visual.json
@@ -176,7 +176,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -217,7 +217,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -258,7 +258,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/81e6d4c870ceb1dc62b0/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/81e6d4c870ceb1dc62b0/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/a4c8aa1fc971a0d42e80/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/a4c8aa1fc971a0d42e80/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/b8383cf770533aecc521/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/b8383cf770533aecc521/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/c21e1d91503e524a196c/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/c21e1d91503e524a196c/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/cdbd012da0d3134b1901/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/cdbd012da0d3134b1901/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/0afdccce6a4bea0bea82/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/0afdccce6a4bea0bea82/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/100c4ba20aaa14ed7a1a/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/100c4ba20aaa14ed7a1a/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/1a84f08231b4e195bbd8/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/1a84f08231b4e195bbd8/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/26cb45fbc20939c4140d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/26cb45fbc20939c4140d/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/32e30324d657383d5c76/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/32e30324d657383d5c76/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/4fc581db481e356dda26/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/4fc581db481e356dda26/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/56c0d6335edeb0c8e480/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/56c0d6335edeb0c8e480/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/6020fd5000ebb4cb728c/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/6020fd5000ebb4cb728c/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/67a296ff8d8bed2d147e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/67a296ff8d8bed2d147e/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/754e9f357b91e0a02594/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/754e9f357b91e0a02594/visual.json
@@ -177,7 +177,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -218,7 +218,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -259,7 +259,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/8071edb164b55a5d3462/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/8071edb164b55a5d3462/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/886360ad47199e2a11e8/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/886360ad47199e2a11e8/visual.json
@@ -39,10 +39,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "users_history"
+                    "Entity": "cal_end_dates"
                   }
                 },
-                "Property": "trueai_user_role_dept"
+                "Property": "year"
               }
             },
             "direction": "Ascending"

--- a/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/a53d768778583d3e1790/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/a53d768778583d3e1790/visual.json
@@ -162,7 +162,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -203,7 +203,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -244,7 +244,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/a8c2d5f026cda6ace244/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/a8c2d5f026cda6ace244/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/0a248e8400b40c4c033d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/0a248e8400b40c4c033d/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/1af4f35d3278300024a0/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/1af4f35d3278300024a0/visual.json
@@ -145,7 +145,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -186,7 +186,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -227,7 +227,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/28a260c3e1492328dc12/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/28a260c3e1492328dc12/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/30216d63e829847c7b51/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/30216d63e829847c7b51/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/40aeaed5691439275710/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/40aeaed5691439275710/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/4b913516c41ad8958ccc/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/4b913516c41ad8958ccc/visual.json
@@ -145,7 +145,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -186,7 +186,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -227,7 +227,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/56973d0e636b56078849/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/56973d0e636b56078849/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/634d874889ed00997631/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/634d874889ed00997631/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/6f0e29146eedb658eab9/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/6f0e29146eedb658eab9/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/7618403961a8b0438229/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/7618403961a8b0438229/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/87dab72b610d114cab51/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/87dab72b610d114cab51/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/bd43a4320c4310706bca/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/bd43a4320c4310706bca/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/d1115b22b0e0498dde63/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/d1115b22b0e0498dde63/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/e0b9b86f6384360799be/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/e0b9b86f6384360799be/visual.json
@@ -39,10 +39,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "users_history"
+                    "Entity": "cal_end_dates"
                   }
                 },
-                "Property": "trueai_user_role_dept"
+                "Property": "year"
               }
             },
             "direction": "Ascending"

--- a/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/0532c6401dd3a14c1e8b/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/0532c6401dd3a14c1e8b/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/1b095298e71b48e03546/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/1b095298e71b48e03546/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/28073ed5e79a3da4a6ba/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/28073ed5e79a3da4a6ba/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/2fdfd9e2610e7d519a2a/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/2fdfd9e2610e7d519a2a/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/3e161f82e3d6e78cd3e9/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/3e161f82e3d6e78cd3e9/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/4e664d22462ad85d4e5e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/4e664d22462ad85d4e5e/visual.json
@@ -144,7 +144,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -185,7 +185,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -226,7 +226,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/5a94562cede480d0440c/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/5a94562cede480d0440c/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/6267373c4a736e831b8d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/6267373c4a736e831b8d/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/6a7c189e008d710947ac/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/6a7c189e008d710947ac/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/7f3bc67907d67a6e7086/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/7f3bc67907d67a6e7086/visual.json
@@ -39,10 +39,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "users_history"
+                    "Entity": "cal_end_dates"
                   }
                 },
-                "Property": "trueai_user_role_dept"
+                "Property": "year"
               }
             },
             "direction": "Ascending"

--- a/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/8cd9bee2cd2780e83a03/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/8cd9bee2cd2780e83a03/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/8df6ccef37b8880bdc4c/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/8df6ccef37b8880bdc4c/visual.json
@@ -144,7 +144,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -185,7 +185,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -226,7 +226,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/b2b8bf6e7b12b05151ee/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/b2b8bf6e7b12b05151ee/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/d8543c2278454122c660/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/d8543c2278454122c660/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/16cfe33fe757de5b11ff/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/16cfe33fe757de5b11ff/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/197dbf32cfd999858af0/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/197dbf32cfd999858af0/visual.json
@@ -175,7 +175,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -216,7 +216,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -257,7 +257,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/31e5ceee0a19866789e0/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/31e5ceee0a19866789e0/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/329213a0496b753a3508/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/329213a0496b753a3508/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/53ef20f1c3e55ed14957/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/53ef20f1c3e55ed14957/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/5c08f618330542d8263d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/5c08f618330542d8263d/visual.json
@@ -39,10 +39,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "users_history"
+                    "Entity": "cal_end_dates"
                   }
                 },
-                "Property": "trueai_user_role_dept"
+                "Property": "year"
               }
             },
             "direction": "Ascending"

--- a/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/5ce9096fe8a6b972b8fc/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/5ce9096fe8a6b972b8fc/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/617474b683cedb2cdc33/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/617474b683cedb2cdc33/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/a66afaab00dbbb786320/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/a66afaab00dbbb786320/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/b536376a927cca2676e4/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/b536376a927cca2676e4/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/c4397ca3493803e169ed/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/c4397ca3493803e169ed/visual.json
@@ -160,7 +160,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -201,7 +201,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -242,7 +242,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/cb65585e2105dc6d3f7d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/cb65585e2105dc6d3f7d/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/d3896b01b21906080d88/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/d3896b01b21906080d88/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/e780001f3904188c54ba/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/e780001f3904188c54ba/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/06c93a4f4b0dba37c806/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/06c93a4f4b0dba37c806/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/0a158750dee820cdbc7e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/0a158750dee820cdbc7e/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/18f5e11e4c63d357e4b1/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/18f5e11e4c63d357e4b1/visual.json
@@ -39,10 +39,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "users_history"
+                    "Entity": "cal_end_dates"
                   }
                 },
-                "Property": "trueai_user_role_dept"
+                "Property": "year"
               }
             },
             "direction": "Ascending"

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/26968a832d47b46b0289/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/26968a832d47b46b0289/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/2fe2336d1e18be706b30/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/2fe2336d1e18be706b30/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/34de297b301c0d720a82/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/34de297b301c0d720a82/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/3ed725c155462285d094/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/3ed725c155462285d094/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/5e088c31d85e769062ec/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/5e088c31d85e769062ec/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/85490531eac03410c684/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/85490531eac03410c684/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/97dd318e6b7558b1010a/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/97dd318e6b7558b1010a/visual.json
@@ -175,7 +175,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -216,7 +216,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -257,7 +257,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/a4dcc82c361d43881b89/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/a4dcc82c361d43881b89/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/b9a0220420ddc10b8d39/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/b9a0220420ddc10b8d39/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/c6a4a6a42ee940114b71/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/c6a4a6a42ee940114b71/visual.json
@@ -160,7 +160,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -201,7 +201,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -242,7 +242,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/e49478df10727189b040/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/e49478df10727189b040/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/1258e0540b37b98ed60a/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/1258e0540b37b98ed60a/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/1642d24fa3bd0e89d503/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/1642d24fa3bd0e89d503/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/39d47697eed156810ee9/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/39d47697eed156810ee9/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/469937313104c4189972/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/469937313104c4189972/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/661fb73d9518c637114e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/661fb73d9518c637114e/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/67a144f27839e7453488/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/67a144f27839e7453488/visual.json
@@ -39,10 +39,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "users_history"
+                    "Entity": "cal_end_dates"
                   }
                 },
-                "Property": "trueai_user_role_dept"
+                "Property": "year"
               }
             },
             "direction": "Ascending"

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/889974b710b230857ad1/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/889974b710b230857ad1/visual.json
@@ -144,7 +144,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -185,7 +185,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -226,7 +226,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/9b1ee723e103ae483b60/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/9b1ee723e103ae483b60/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/c851afca267c730c8979/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/c851afca267c730c8979/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/cd08f7ca76ee0365270b/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/cd08f7ca76ee0365270b/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/d30b5143d66dd1bd7cd7/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/d30b5143d66dd1bd7cd7/visual.json
@@ -144,7 +144,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -185,7 +185,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -226,7 +226,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/d61e44cfd179a303acc4/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/d61e44cfd179a303acc4/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/da72b38dda0a06e58ba0/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/da72b38dda0a06e58ba0/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/fc6566b2a61d3ebe0462/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/fc6566b2a61d3ebe0462/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/036bd0be8ac989b43095/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/036bd0be8ac989b43095/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/1ee9a54046dade312cde/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/1ee9a54046dade312cde/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/22711c9c53bccc6a00ca/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/22711c9c53bccc6a00ca/visual.json
@@ -39,10 +39,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "users_history"
+                    "Entity": "cal_end_dates"
                   }
                 },
-                "Property": "trueai_user_role_dept"
+                "Property": "year"
               }
             },
             "direction": "Ascending"

--- a/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/24f14fd3158446b8a8a6/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/24f14fd3158446b8a8a6/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/387fd2843364c463e878/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/387fd2843364c463e878/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/38a211a0d780a7de4b81/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/38a211a0d780a7de4b81/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/43519e066149b5e0de63/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/43519e066149b5e0de63/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/472e4c4773033844e746/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/472e4c4773033844e746/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/66d927d406615497ad8c/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/66d927d406615497ad8c/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/766fc9702b48e143239e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/766fc9702b48e143239e/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/775f50dd70b07534edb0/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/775f50dd70b07534edb0/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/8fb26dc110217d9a08d0/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/8fb26dc110217d9a08d0/visual.json
@@ -297,7 +297,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "ssr"
+                "Entity": "quality_buckets"
               }
             },
             "Property": "col.trueai_propensity_min_max_tier_pros"

--- a/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/96ed8f025e6e1475c28e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/96ed8f025e6e1475c28e/visual.json
@@ -144,7 +144,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -185,7 +185,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -226,7 +226,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"

--- a/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/b62bb64c91c9c37b7c40/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/b62bb64c91c9c37b7c40/visual.json
@@ -144,7 +144,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -185,7 +185,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"
@@ -226,7 +226,7 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "hat_leads"
+                            "Entity": "ssr"
                           }
                         },
                         "Property": "trueai_industry"


### PR DESCRIPTION
## Summary
- Replaced stale copied visual references across Strategy Report Segmentation pages.
- Remapped removed/old fields such as `hat_leads`, `managers_direct`, legacy user role columns, and obsolete propensity bucket fields to current semantic model fields.
- Includes updated `Strategy Report.pbix` alongside the report definition JSON changes.

## Validation
- Segmentation model-reference scan: `Missing references: 0`
- Changed JSON parse check: `Changed JSON: 173`, `Bad JSON: 0`

## Notes
- Direct push to `staging` was blocked by branch protection, so this PR targets `staging` instead.