### PR TITLE
Fix stale Strategy Report visual references

### DIFF
--- a/powerbi/Strategy Report.pbix
+++ b/powerbi/Strategy Report.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8805fb67726df553fec9e1bef73b19005ce17dafd60b0bc328296aad1a60a960
-size 8544960
+oid sha256:9d4e75d0ae97b29358dab97b6361d9d2c944a311fee052609fe79c6ec9535b58
+size 8544450

--- a/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/02e12a804d6c52072a5d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/02e12a804d6c52072a5d/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/1a64a389b6ed4ecaf49f/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/1a64a389b6ed4ecaf49f/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/7833ceb2c08e82ceb7bd/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/7833ceb2c08e82ceb7bd/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/946f781ef1fedd4b8f8d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/946f781ef1fedd4b8f8d/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/a7303cc388f163c364ab/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/a7303cc388f163c364ab/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/ba7a415591b4ab7fa373/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/ba7a415591b4ab7fa373/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/f4d05f1a47db40d84526/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/f4d05f1a47db40d84526/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/1dc32e1371c682c42dc5/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/1dc32e1371c682c42dc5/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/266e91351b5ed75c2acc/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/266e91351b5ed75c2acc/visual.json
@@ -247,7 +247,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/2a71f22b7e27b7d2e4d0/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/2a71f22b7e27b7d2e4d0/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/8e940fbf596ebfc5deba/visuals/5611888bc2308260476b/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/8e940fbf596ebfc5deba/visuals/5611888bc2308260476b/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/8e940fbf596ebfc5deba/visuals/5ebd1862ce62ed911bf1/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/8e940fbf596ebfc5deba/visuals/5ebd1862ce62ed911bf1/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/8e940fbf596ebfc5deba/visuals/aea85cd9c29630ee4a13/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/8e940fbf596ebfc5deba/visuals/aea85cd9c29630ee4a13/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/8e940fbf596ebfc5deba/visuals/f57dd0d0e55324828f3e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/8e940fbf596ebfc5deba/visuals/f57dd0d0e55324828f3e/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/9613185c0b5d01cc2e8b/visuals/845b1c600743327275d6/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9613185c0b5d01cc2e8b/visuals/845b1c600743327275d6/visual.json
@@ -247,7 +247,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/9613185c0b5d01cc2e8b/visuals/976c9d07965cc99b7395/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9613185c0b5d01cc2e8b/visuals/976c9d07965cc99b7395/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/9613185c0b5d01cc2e8b/visuals/994a5f15dac8c4d5c329/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9613185c0b5d01cc2e8b/visuals/994a5f15dac8c4d5c329/visual.json
@@ -39,10 +39,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "users_history"
+                    "Entity": "cal_end_dates"
                   }
                 },
-                "Property": "trueai_user_role_dept"
+                "Property": "year"
               }
             },
             "direction": "Ascending"

--- a/powerbi/src/Strategy Report.Report/definition/pages/9613185c0b5d01cc2e8b/visuals/9d703f3be9b60017d0dc/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9613185c0b5d01cc2e8b/visuals/9d703f3be9b60017d0dc/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/30a1af738672336b7eaf/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/30a1af738672336b7eaf/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/33576625669d55fc82e4/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/33576625669d55fc82e4/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/3e1c0b553387a76c015a/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/3e1c0b553387a76c015a/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/42530ab9d6e58f61ab64/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/42530ab9d6e58f61ab64/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/a0bfccfb6ed269044cde/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/a0bfccfb6ed269044cde/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/abc820bac9b21b1ee482/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/abc820bac9b21b1ee482/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/af7ff8e08d4edfcdc801/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/af7ff8e08d4edfcdc801/visual.json
@@ -113,7 +113,7 @@
                 "Entity": "users_history"
               }
             },
-            "Property": "col.trueai_user_role_coid_aliased"
+            "Property": "trueai_user_role_alias"
           }
         },
         "type": "Categorical",

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/b1ddf170960b93cd7148/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/b1ddf170960b93cd7148/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/c1b263258ceedff003ec/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/c1b263258ceedff003ec/visual.json
@@ -113,7 +113,7 @@
                 "Entity": "users_history"
               }
             },
-            "Property": "col.trueai_user_role_coid_aliased"
+            "Property": "trueai_user_role_alias"
           }
         },
         "type": "Categorical",

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/de972e73c64c174d354a/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/de972e73c64c174d354a/visual.json
@@ -113,7 +113,7 @@
                 "Entity": "users_history"
               }
             },
-            "Property": "col.trueai_user_role_coid_aliased"
+            "Property": "trueai_user_role_alias"
           }
         },
         "type": "Categorical",

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection1252b003407e4ccc57ae/visuals/58d39010e53b9c2b9e5d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection1252b003407e4ccc57ae/visuals/58d39010e53b9c2b9e5d/visual.json
@@ -247,7 +247,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection1252b003407e4ccc57ae/visuals/9b5298e1289c944b0bec/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection1252b003407e4ccc57ae/visuals/9b5298e1289c944b0bec/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/33d547197e43c07fd755/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/33d547197e43c07fd755/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/4702721201706d74a63d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/4702721201706d74a63d/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/77ef29725d13a38dc05b/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/77ef29725d13a38dc05b/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -138,7 +138,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept2",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/a01a1b3cc6d7d785de7e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/a01a1b3cc6d7d785de7e/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/adc6038ddefacf4f23e7/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/adc6038ddefacf4f23e7/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/bde68f03020985b0d07e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/bde68f03020985b0d07e/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/c9f7147812623d3753de/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/c9f7147812623d3753de/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/d051cbe0c3e3ebc2a3ed/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/d051cbe0c3e3ebc2a3ed/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/d3d4b77d87d3533949a7/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/d3d4b77d87d3533949a7/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/e489c40db7d0967e566e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/e489c40db7d0967e566e/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/eb6ece281f5b8c4d0133/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/eb6ece281f5b8c4d0133/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/fab7046e7423cd9b2a1c/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/fab7046e7423cd9b2a1c/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/fd40f0e9d5896c3eae70/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/fd40f0e9d5896c3eae70/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/055c90ffd2a097a01896/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/055c90ffd2a097a01896/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/063fa6d2a6c7e350b03c/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/063fa6d2a6c7e350b03c/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/1701dd4dd440654f5876/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/1701dd4dd440654f5876/visual.json
@@ -342,10 +342,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "users_history"
+                            "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "trueai_user_role_dept"
+                        "Property": "year"
                       }
                     },
                     "Right": {
@@ -384,10 +384,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "users_history"
+                            "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "trueai_user_role_dept"
+                        "Property": "year"
                       }
                     },
                     "Right": {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/2261d56d0802c6375356/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/2261d56d0802c6375356/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/3b7686a631dc3d9c8e81/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/3b7686a631dc3d9c8e81/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/6bb9cc23e05da5bc61eb/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/6bb9cc23e05da5bc61eb/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/95bc3d7a1077f77ad620/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/95bc3d7a1077f77ad620/visual.json
@@ -284,10 +284,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "users_history"
+                            "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "trueai_user_role_dept"
+                        "Property": "year"
                       }
                     },
                     "Right": {
@@ -326,10 +326,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "users_history"
+                            "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "trueai_user_role_dept"
+                        "Property": "year"
                       }
                     },
                     "Right": {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/a0b3621b6cde52abcf7a/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/a0b3621b6cde52abcf7a/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/d340dc9571baf4018896/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/d340dc9571baf4018896/visual.json
@@ -271,10 +271,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "users_history"
+                            "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "trueai_user_role_dept"
+                        "Property": "year"
                       }
                     },
                     "Right": {
@@ -313,10 +313,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "users_history"
+                            "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "trueai_user_role_dept"
+                        "Property": "year"
                       }
                     },
                     "Right": {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/fe9b61f5081f9aff1fac/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/fe9b61f5081f9aff1fac/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/009312dcc9a48b00a916/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/009312dcc9a48b00a916/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/2476ae436689587e797d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/2476ae436689587e797d/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/25ec3ba9422a44fc0623/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/25ec3ba9422a44fc0623/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/8c8e55089e357bca6d9b/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/8c8e55089e357bca6d9b/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/ba9c6358b3b7032e5552/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/ba9c6358b3b7032e5552/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/f6f06eaf1ab30e8c423c/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/f6f06eaf1ab30e8c423c/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/f750f1761555bd18c3a1/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/f750f1761555bd18c3a1/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/0abb823302ffe70f9bb2/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/0abb823302ffe70f9bb2/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/331c015caf28b84bf4b2/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/331c015caf28b84bf4b2/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/4d156cb4f342913cbd5f/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/4d156cb4f342913cbd5f/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/94a0836479085a4f0945/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/94a0836479085a4f0945/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/9a2f1ec8cd4d2609b5c5/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/9a2f1ec8cd4d2609b5c5/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/d65bf19c908539550194/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/d65bf19c908539550194/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/f04a25b38c65ad51b908/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/f04a25b38c65ad51b908/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/1d6073ca32b709e98a07/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/1d6073ca32b709e98a07/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/62c0fd4e7b01523fee33/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/62c0fd4e7b01523fee33/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/6458df7e2c3fa8c0528a/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/6458df7e2c3fa8c0528a/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/645d04255ef61679a90e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/645d04255ef61679a90e/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/7a35d7db3c1d0371f4d3/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/7a35d7db3c1d0371f4d3/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/8aa205d5fe1dac5fd15b/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/8aa205d5fe1dac5fd15b/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/e2570cec5bf6fbe97b11/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/e2570cec5bf6fbe97b11/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/050b62f4b9626fce31a0/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/050b62f4b9626fce31a0/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/1e8ae4868370184a4c59/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/1e8ae4868370184a4c59/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/4dde487346e65d1a27b2/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/4dde487346e65d1a27b2/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/510e3109549c85871ba3/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/510e3109549c85871ba3/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/a6c2dccbc845d1b43c51/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/a6c2dccbc845d1b43c51/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/c63d32cd189842c6b185/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/c63d32cd189842c6b185/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/ea9611c7b19932c5fa02/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/ea9611c7b19932c5fa02/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/13a639c472fe34cc4a34/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/13a639c472fe34cc4a34/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/31e199d600fd3cf01b14/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/31e199d600fd3cf01b14/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/46e68bc6cf029a812a07/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/46e68bc6cf029a812a07/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/68cfe25bb5178e51a3be/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/68cfe25bb5178e51a3be/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/de1ae60f0c88597939af/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/de1ae60f0c88597939af/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/ed08fcb25a2dee15ce29/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/ed08fcb25a2dee15ce29/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/fdac53855bf925b236a3/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/fdac53855bf925b236a3/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/08a5471b5a32e13011ad/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/08a5471b5a32e13011ad/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/58c8064dc8bab8fa8ab7/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/58c8064dc8bab8fa8ab7/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/6f3f48476c639de29118/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/6f3f48476c639de29118/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/88117f74550bb3840131/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/88117f74550bb3840131/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/b1b513d7b656bdd3280b/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/b1b513d7b656bdd3280b/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/c169ddb4792db1bb98a2/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/c169ddb4792db1bb98a2/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/fa3900c0bca8caef4455/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/fa3900c0bca8caef4455/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/40d35259d05c08c46277/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/40d35259d05c08c46277/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/5fc91735fdd1ef2424a5/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/5fc91735fdd1ef2424a5/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/8d0813a69e71b51a699e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/8d0813a69e71b51a699e/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/8fb48395d46afde9ed1d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/8fb48395d46afde9ed1d/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/95ec3eced9ab6078d72d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/95ec3eced9ab6078d72d/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/bd3d498479bf0401304d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/bd3d498479bf0401304d/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/cd0cbbbb41b0fdd6be3f/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/cd0cbbbb41b0fdd6be3f/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/23bc3bdc73ecc44d139d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/23bc3bdc73ecc44d139d/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/5c43c6dceb36ee1e7719/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/5c43c6dceb36ee1e7719/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/65ac02a3875c6db830f7/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/65ac02a3875c6db830f7/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/9ef30b04c60383dc92c6/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/9ef30b04c60383dc92c6/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/ba12ea324a69aab1371b/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/ba12ea324a69aab1371b/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/ceeecf9cd5bb9861045a/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/ceeecf9cd5bb9861045a/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/fe25a94aa366be55fc5b/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/fe25a94aa366be55fc5b/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/0661991dd52032a411fe/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/0661991dd52032a411fe/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/2632650f528276ad4a47/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/2632650f528276ad4a47/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/60b8ae48bfa89b0d2b54/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/60b8ae48bfa89b0d2b54/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/7022cf5e8609d8cd10b8/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/7022cf5e8609d8cd10b8/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/ca530c06081d70001b23/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/ca530c06081d70001b23/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/f01b26cdda46883be95b/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/f01b26cdda46883be95b/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/f3dc98d070b87a0b3f02/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/f3dc98d070b87a0b3f02/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/2092f7cb7c6db7a3053b/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/2092f7cb7c6db7a3053b/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/234f0d325e8279dc546a/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/234f0d325e8279dc546a/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/2c351573532477cf35b0/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/2c351573532477cf35b0/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/524064413354557aeb5d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/524064413354557aeb5d/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/555d46ac16cd002a2857/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/555d46ac16cd002a2857/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/ba96d30b5f16531aa1a0/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/ba96d30b5f16531aa1a0/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/fb0619cebca586eff66e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/fb0619cebca586eff66e/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/250ec776a5082348749c/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/250ec776a5082348749c/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/45600f3f112494bcb8da/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/45600f3f112494bcb8da/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/8729d5646b47d56cee7a/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/8729d5646b47d56cee7a/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/9cdfc7246083f3f7c65e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/9cdfc7246083f3f7c65e/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/b8b75838a513104d460f/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/b8b75838a513104d460f/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/edbeb890050e0db986b0/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/edbeb890050e0db986b0/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/f6524a15ad747a8e8933/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/f6524a15ad747a8e8933/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/14552a9deebcd2bffff0/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/14552a9deebcd2bffff0/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/193ed251485940b8e86c/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/193ed251485940b8e86c/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/2b0681bf75bb5cdcaa8a/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/2b0681bf75bb5cdcaa8a/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/5946262ab6b8df350d86/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/5946262ab6b8df350d86/visual.json
@@ -842,7 +842,7 @@
                 "Entity": "users_history"
               }
             },
-            "Property": "col.trueai_user_role_coid_aliased"
+            "Property": "trueai_user_role_alias"
           }
         },
         "type": "Categorical",

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/6ec05cde2a621654b1d5/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/6ec05cde2a621654b1d5/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/730f33354263a33ef3a1/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/730f33354263a33ef3a1/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/c4ea74789bf6445e974d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/c4ea74789bf6445e974d/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/d19b29f19c9ec33a3148/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/d19b29f19c9ec33a3148/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/057ccc304ff9a653843e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/057ccc304ff9a653843e/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/2291815dba78072b65ca/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/2291815dba78072b65ca/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/4c7421a2cc41dccc3f18/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/4c7421a2cc41dccc3f18/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/5d5e4ef1c9774ad423fb/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/5d5e4ef1c9774ad423fb/visual.json
@@ -39,10 +39,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "users_history"
+                    "Entity": "cal_end_dates"
                   }
                 },
-                "Property": "trueai_user_role_dept"
+                "Property": "year"
               }
             },
             "direction": "Ascending"

--- a/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/626657533932af90ac6f/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/626657533932af90ac6f/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/9c5e1c554b7178bea09b/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/9c5e1c554b7178bea09b/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/ac9a6a8722467d96e347/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/ac9a6a8722467d96e347/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/bde5b858ebce6cadb6e3/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/bde5b858ebce6cadb6e3/visual.json
@@ -39,10 +39,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "users_history"
+                    "Entity": "cal_end_dates"
                   }
                 },
-                "Property": "trueai_user_role_dept"
+                "Property": "year"
               }
             },
             "direction": "Ascending"

--- a/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/ee76c3d6bb28977553f5/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/ee76c3d6bb28977553f5/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/111bf16788a7430d1dd2/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/111bf16788a7430d1dd2/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.trueai_user_role_coid_aliased"
+                  "Property": "trueai_user_role_alias"
                 }
               },
-              "queryRef": "users.col.trueai_user_role_coid_aliased",
-              "nativeQueryRef": "col.trueai_user_role_coid_aliased",
+              "queryRef": "users.trueai_user_role_alias",
+              "nativeQueryRef": "trueai_user_role_alias",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/17e37d1320ac9805779b/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/17e37d1320ac9805779b/visual.json
@@ -478,7 +478,7 @@
           "Column": {
             "Expression": {
               "SourceRef": {
-                "Entity": "aliasing"
+                "Entity": "metadata_aliasing"
               }
             },
             "Property": "label"
@@ -490,7 +490,7 @@
           "From": [
             {
               "Name": "a",
-              "Entity": "aliasing",
+              "Entity": "metadata_aliasing",
               "Type": 0
             }
           ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/18d210a4aba7b7b58857/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/18d210a4aba7b7b58857/visual.json
@@ -20,14 +20,14 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "managers_direct"
+                      "Entity": "users"
                     }
                   },
                   "Property": "trueai_full_name"
                 }
               },
-              "queryRef": "managers_direct.trueai_full_name",
-              "nativeQueryRef": "trueai_full_name1",
+              "queryRef": "users.trueai_full_name",
+              "nativeQueryRef": "trueai_full_name",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/19945052119892e0037a/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/19945052119892e0037a/visual.json
@@ -139,7 +139,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/95b3e5161ee068a93816/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/95b3e5161ee068a93816/visual.json
@@ -20,13 +20,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "hat_leads"
+                      "Entity": "ssr_history"
                     }
                   },
-                  "Property": "trueai_propensity"
+                  "Property": "entity_propensity"
                 }
               },
-              "queryRef": "hatleads.trueai_propensity",
+              "queryRef": "ssr_history.entity_propensity",
               "active": true,
               "displayName": "Propensity"
             }

--- a/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/b61ea13281c3095059dd/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/b61ea13281c3095059dd/visual.json
@@ -246,7 +246,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.trueai_user_role_coid_aliased",
+      "groupName": "trueai_user_role_alias",
       "fieldChanges": true,
       "filterChanges": true
     },

--- a/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/bb0361e3a959b3579466/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/bb0361e3a959b3579466/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "col.user_role_dept"
+                  "Property": "trueai_user_role_function"
                 }
               },
-              "queryRef": "users.col.user_role_dept",
+              "queryRef": "users.trueai_user_role_function",
               "active": true
             }
           ]
@@ -188,7 +188,7 @@
       ]
     },
     "syncGroup": {
-      "groupName": "col.user_role_dept1",
+      "groupName": "trueai_user_role_function",
       "fieldChanges": true,
       "filterChanges": true
     },


### PR DESCRIPTION
## Summary
- Replaced stale Strategy Report visual references that were still pointing at removed/renamed model fields.
- Updated both the report source JSON visuals and `powerbi/Strategy Report.pbix` so the packaged report stays aligned with source.
- Leaves `.cleanwork/` untouched and untracked.

## Root Cause
Segmentation embed failures were still happening because `staging` contained copied/hidden Strategy Report visuals with old references such as `hat_leads`, `managers_direct`, `users[col.user_role_dept]`, and `users[col.trueai_user_role_coid_aliased]`. Power BI can fail embed rendering when any included report visual points at missing fields.

## Validation
- Known stale reference scan across `powerbi/src/Strategy Report.Report`: no matches.
- Changed visual JSON parse check: `Changed JSON bad: 0`.
- Changed visual semantic reference check: `Changed missing references: 0`.