### PR TITLE
Fix stale segmentation card bindings

### DIFF
--- a/powerbi/Strategy Report.pbix
+++ b/powerbi/Strategy Report.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9d4e75d0ae97b29358dab97b6361d9d2c944a311fee052609fe79c6ec9535b58
-size 8544450
+oid sha256:c9bc277782a0d846cfd661152d2e4d317c53b3c9877fbceb89fc6552161fa7cd
+size 8544141

--- a/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/2d5205e1066033ab8076/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1313930abe3402a6e895/visuals/2d5205e1066033ab8076/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/540528c2186c3a6e2c0a/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/540528c2186c3a6e2c0a/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/b0212cb6c740a6ca2513/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/b0212cb6c740a6ca2513/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/b0e2d0d4c046900207bd/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/b0e2d0d4c046900207bd/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/236d19ba89e8202d3139/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/622a53233633480da0ae/visuals/236d19ba89e8202d3139/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/24fbacd4a2b6de4d7cc4/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/696d661f070dd41a7206/visuals/24fbacd4a2b6de4d7cc4/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/3ec7131d7bb5bb7814d7/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7b9270b0122a87081a97/visuals/3ec7131d7bb5bb7814d7/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/177f70c016a0390bb037/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/177f70c016a0390bb037/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/9e39ed9e08c23aeba896/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/9e39ed9e08c23aeba896/visual.json
@@ -20,14 +20,14 @@
                 "Measure": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "companies_history"
+                      "Entity": "metadata_heatmap_items"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.heatmap_details_growth_category_base64"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "metadata_heatmap_items.meas.heatmap_details_growth_category_base64",
+              "nativeQueryRef": "meas.heatmap_details_growth_category_base64"
             }
           ]
         }
@@ -39,10 +39,10 @@
               "Measure": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "companies_history"
+                    "Entity": "metadata_heatmap_items"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.heatmap_details_growth_category_base64"
               }
             },
             "direction": "Descending"
@@ -118,7 +118,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "metadata_heatmap_items.meas.heatmap_details_growth_category_base64"
           }
         }
       ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/bd9dc04ec23010a27b80/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7d954e6a40dc7a55d370/visuals/bd9dc04ec23010a27b80/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/8e940fbf596ebfc5deba/visuals/656510c0015d150837a1/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/8e940fbf596ebfc5deba/visuals/656510c0015d150837a1/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/9613185c0b5d01cc2e8b/visuals/c4da810f725275388d31/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9613185c0b5d01cc2e8b/visuals/c4da810f725275388d31/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/d0d8f96e6d4402e405d5/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9a7761f3d0b5d13c31b4/visuals/d0d8f96e6d4402e405d5/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/35d0add9703278d88a7a/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/35d0add9703278d88a7a/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection1252b003407e4ccc57ae/visuals/d551e8a7c964e18385c9/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection1252b003407e4ccc57ae/visuals/d551e8a7c964e18385c9/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/cfc860ef1d433036a02d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/cfc860ef1d433036a02d/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/56159fcc84ec0a7ba8e0/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/56159fcc84ec0a7ba8e0/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/d5dd94e3868e77e1b659/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/d5dd94e3868e77e1b659/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/51c7accf490a18049190/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/51c7accf490a18049190/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/024a04a4c06a80d7034b/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/024a04a4c06a80d7034b/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/b6b3bf817007038e790e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/b6b3bf817007038e790e/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/798f3f5a14d4701d15bc/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/798f3f5a14d4701d15bc/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/67c885d0de93d824d45c/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiona1953eed9a96c05789af/visuals/67c885d0de93d824d45c/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/14d2f5d15d9cc449a9a2/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/14d2f5d15d9cc449a9a2/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/3f625fd114c6169d0cca/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/3f625fd114c6169d0cca/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/f745246153ebc7b660c1/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/f745246153ebc7b660c1/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/c90fc754db8153439b9c/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/c90fc754db8153439b9c/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/093f721ee2d4c16bca42/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/093f721ee2d4c16bca42/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/891299283a2d34540126/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/891299283a2d34540126/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/03699ca68be9da884e89/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/03699ca68be9da884e89/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/4fead2b505134c3c9d8b/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/4fead2b505134c3c9d8b/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/1e1299c1023a45220e49/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b8914151d503db62b151/visuals/1e1299c1023a45220e49/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/fd54e911e2836780d2c0/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/bc74a4ff28fe9a0abc93/visuals/fd54e911e2836780d2c0/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/5411d6962578c33aa708/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9b61f7e0b169be683e4/visuals/5411d6962578c33aa708/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/bc9d6cb94e69caa50c78/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/c9f4197fb1d9c484cecd/visuals/bc9d6cb94e69caa50c78/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/5b8b2810a07bc0c78ccd/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/d32b59d645711c6c6a4a/visuals/5b8b2810a07bc0c78ccd/visual.json
@@ -23,11 +23,11 @@
                       "Entity": "companies_history"
                     }
                   },
-                  "Property": "meas.company_history_partnerLogo"
+                  "Property": "meas.companies_history_partner_base64_logo"
                 }
               },
-              "queryRef": "companies_history.meas.company_history_partnerLogo",
-              "nativeQueryRef": "meas.company_history_partnerLogo"
+              "queryRef": "companies_history.meas.companies_history_partner_base64_logo",
+              "nativeQueryRef": "meas.companies_history_partner_base64_logo"
             }
           ]
         }
@@ -42,7 +42,7 @@
                     "Entity": "companies_history"
                   }
                 },
-                "Property": "meas.company_history_partnerLogo"
+                "Property": "meas.companies_history_partner_base64_logo"
               }
             },
             "direction": "Descending"
@@ -132,7 +132,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -275,7 +275,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ],
@@ -291,7 +291,7 @@
             }
           },
           "selector": {
-            "metadata": "companies_history.meas.company_history_partnerLogo"
+            "metadata": "companies_history.meas.companies_history_partner_base64_logo"
           }
         }
       ]


### PR DESCRIPTION
## Summary

Fixes remaining Power BI `Missing_References` failures on Strategy Report card visuals by aligning their hidden data, sort, and metadata bindings with the actual image URL measure displayed by each card.

## Root Cause

Several untitled card visuals still referenced `companies_history[meas.company_history_partnerLogo]` in their data bucket/sort/selector metadata. That measure is stale/empty, while the visuals were already displaying a valid image URL measure. Power BI surfaced this as `Could not render a report visual titled: undefined` because these card visuals have no title.

## Changes

- Updated 36 Strategy Report card visual JSON files.
- Removed stale `company_history_partnerLogo` bindings.
- Preserved the visible images by retargeting each card's hidden bindings to the image measure already used by that visual.

## Validation

- Confirmed no remaining `company_history_partnerLogo` references in `powerbi/src/Strategy Report.Report`.
- Parsed all Strategy Report `visual.json` files successfully: `Bad JSON count: 0`.
- Verified changed card visual data bindings match their image URL bindings: `Changed card binding issues: 0`.

## Note

The untracked local `.cleanwork/` folder was intentionally not included.