### PR TITLE
Revert PR #687 Strategy Report stale visual reference changes

### DIFF
--- a/powerbi/Strategy Report.pbix
+++ b/powerbi/Strategy Report.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ba35a9c0bd9cc86a43380e1e01b0afc93b090a6d03d3db8ef7817632cc7d6a38
-size 8537183
+oid sha256:c9bc277782a0d846cfd661152d2e4d317c53b3c9877fbceb89fc6552161fa7cd
+size 8544141

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/023f2fab0634a9ed2374/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/023f2fab0634a9ed2374/visual.json
@@ -26,7 +26,7 @@
                   "Property": "col.propensity_min_max_tier"
                 }
               },
-              "queryRef": "quality_buckets.col.propensity_min_max_tier",
+              "queryRef": "quality_buckets.col.propensity_min_max_tier_test",
               "nativeQueryRef": "Propensity",
               "active": true,
               "displayName": "Propensity"

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/34d63186af821f96005d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/34d63186af821f96005d/visual.json
@@ -26,7 +26,7 @@
                   "Property": "col.propensity_min_max_tier"
                 }
               },
-              "queryRef": "quality_buckets.col.propensity_min_max_tier",
+              "queryRef": "quality_buckets.col.propensity_min_max_tier_test",
               "nativeQueryRef": "Propensity (Tier)1",
               "displayName": "Propensity (Tier)"
             },
@@ -42,8 +42,8 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_success_prob_avg_post_sales",
-              "nativeQueryRef": "Avg. Pred. New Deal Creation Rate Â¹",
-              "displayName": "Avg. Pred. New Deal Creation Rate Â¹"
+              "nativeQueryRef": "Avg. Pred. New Deal Creation Rate ¹",
+              "displayName": "Avg. Pred. New Deal Creation Rate ¹"
             },
             {
               "field": {
@@ -87,8 +87,8 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_duration_hrs_per_acct_post_sales",
-              "nativeQueryRef": "Avg. Time per Deal in Post-Sales Support Â²",
-              "displayName": "Avg. Time per Deal in Post-Sales Support Â²"
+              "nativeQueryRef": "Avg. Time per Deal in Post-Sales Support ²",
+              "displayName": "Avg. Time per Deal in Post-Sales Support ²"
             },
             {
               "field": {
@@ -102,8 +102,8 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_duration_hrs_post_sales",
-              "nativeQueryRef": "Tot. Time Spent - Post Sales Support Â²",
-              "displayName": "Tot. Time Spent - Post Sales Support Â²"
+              "nativeQueryRef": "Tot. Time Spent - Post Sales Support ²",
+              "displayName": "Tot. Time Spent - Post Sales Support ²"
             },
             {
               "field": {
@@ -501,7 +501,7 @@
                 }
               }
             ],
-            "metadata": "quality_buckets.col.propensity_min_max_tier"
+            "metadata": "quality_buckets.col.propensity_min_max_tier_test"
           }
         }
       ],
@@ -678,7 +678,7 @@
             }
           },
           "selector": {
-            "metadata": "quality_buckets.col.propensity_min_max_tier"
+            "metadata": "quality_buckets.col.propensity_min_max_tier_test"
           }
         },
         {

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/9c184f3d6912ea38b3e8/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/9c184f3d6912ea38b3e8/visual.json
@@ -26,7 +26,7 @@
                   "Property": "col.propensity_min_max_tier"
                 }
               },
-              "queryRef": "quality_buckets.col.propensity_min_max_tier",
+              "queryRef": "quality_buckets.col.propensity_min_max_tier_test",
               "nativeQueryRef": "Propensity",
               "active": true,
               "displayName": "Propensity"

--- a/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/d11fda64e42b107e7ceb/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/1620767c4c0ce5527c53/visuals/d11fda64e42b107e7ceb/visual.json
@@ -26,7 +26,7 @@
                   "Property": "col.propensity_min_max_tier"
                 }
               },
-              "queryRef": "quality_buckets.col.propensity_min_max_tier",
+              "queryRef": "quality_buckets.col.propensity_min_max_tier_test",
               "nativeQueryRef": "Propensity (Tier)1",
               "displayName": "Propensity (Tier)"
             },
@@ -42,8 +42,8 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_success_prob_avg_existing_customer_selling",
-              "nativeQueryRef": "Avg. Pred. Win Rate Â¹",
-              "displayName": "Avg. Pred. Win Rate Â¹"
+              "nativeQueryRef": "Avg. Pred. Win Rate ¹",
+              "displayName": "Avg. Pred. Win Rate ¹"
             },
             {
               "field": {
@@ -102,8 +102,8 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_duration_hrs_per_acct_existing_customer_selling",
-              "nativeQueryRef": "Avg. Time Spent per Acct. Existing Cust. Selling Â²",
-              "displayName": "Avg. Time Spent per Acct. Existing Cust. Selling Â²"
+              "nativeQueryRef": "Avg. Time Spent per Acct. Existing Cust. Selling ²",
+              "displayName": "Avg. Time Spent per Acct. Existing Cust. Selling ²"
             },
             {
               "field": {
@@ -117,8 +117,8 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_duration_hrs_existing_customer_selling",
-              "nativeQueryRef": "Tot. Time Spent - Existing Cust. Selling Â²",
-              "displayName": "Tot. Time Spent - Existing Cust. Selling Â²"
+              "nativeQueryRef": "Tot. Time Spent - Existing Cust. Selling ²",
+              "displayName": "Tot. Time Spent - Existing Cust. Selling ²"
             },
             {
               "field": {
@@ -516,7 +516,7 @@
                 }
               }
             ],
-            "metadata": "quality_buckets.col.propensity_min_max_tier"
+            "metadata": "quality_buckets.col.propensity_min_max_tier_test"
           }
         }
       ],
@@ -614,7 +614,7 @@
             }
           },
           "selector": {
-            "metadata": "quality_buckets.col.propensity_min_max_tier"
+            "metadata": "quality_buckets.col.propensity_min_max_tier_test"
           }
         },
         {

--- a/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/06fcaea7424090441722/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/06fcaea7424090441722/visual.json
@@ -167,10 +167,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -198,10 +198,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -229,10 +229,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -260,10 +260,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -291,10 +291,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -322,10 +322,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -353,10 +353,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {

--- a/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/2b19360f6ee23f6a244e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/2b19360f6ee23f6a244e/visual.json
@@ -1699,10 +1699,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "ssr_history"
+                    "Entity": "users_history"
                   }
                 },
-                "Property": "vi_value_repeat"
+                "Property": "vi_value_received_total"
               }
             },
             "Function": 0
@@ -1735,10 +1735,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "ssr_history"
+                    "Entity": "users_history"
                   }
                 },
-                "Property": "vi_value_created"
+                "Property": "vi_value_created_selling"
               }
             },
             "Function": 0

--- a/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/7ff6ace2b1b99c8772e4/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/20e1a4ec81d6719c331e/visuals/7ff6ace2b1b99c8772e4/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Date Year1",
               "active": true
             }
@@ -154,7 +154,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Name": "VariaciÃ³n",
+                        "Name": "Variación",
                         "Property": "Date"
                       }
                     },
@@ -635,7 +635,7 @@
                     "Entity": "users_history"
                   }
                 },
-                "Property": "ci_time_alloc_existing_customer_selling"
+                "Property": "ci_time_alloc_upselling"
               }
             },
             "Function": 1
@@ -752,7 +752,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/b50a30c8d29a41766b77/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/b50a30c8d29a41766b77/visual.json
@@ -26,7 +26,7 @@
                   "Property": "col.propensity_min_max_tier"
                 }
               },
-              "queryRef": "quality_buckets.col.propensity_min_max_tier",
+              "queryRef": "quality_buckets.col.propensity_min_max_tier_test",
               "nativeQueryRef": "Propensity (Tier)1",
               "displayName": "Propensity (Tier)"
             },
@@ -42,8 +42,8 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_success_prob_avg_new_logo",
-              "nativeQueryRef": "Avg. Pred. Win Rate Â¹",
-              "displayName": "Avg. Pred. Win Rate Â¹"
+              "nativeQueryRef": "Avg. Pred. Win Rate ¹",
+              "displayName": "Avg. Pred. Win Rate ¹"
             },
             {
               "field": {
@@ -102,8 +102,8 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_duration_hrs_per_acct_new_logo",
-              "nativeQueryRef": "Avg. Time Spent per Acct. New Logo Selling Â²",
-              "displayName": "Avg. Time Spent per Acct. New Logo Selling Â²"
+              "nativeQueryRef": "Avg. Time Spent per Acct. New Logo Selling ²",
+              "displayName": "Avg. Time Spent per Acct. New Logo Selling ²"
             },
             {
               "field": {
@@ -117,7 +117,7 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_duration_hrs_new_logo",
-              "displayName": "Tot. Time Spent - New Logo Selling Â²"
+              "displayName": "Tot. Time Spent - New Logo Selling ²"
             },
             {
               "field": {
@@ -500,7 +500,7 @@
                 }
               }
             ],
-            "metadata": "quality_buckets.col.propensity_min_max_tier"
+            "metadata": "quality_buckets.col.propensity_min_max_tier_test"
           }
         }
       ],
@@ -633,7 +633,7 @@
             }
           },
           "selector": {
-            "metadata": "quality_buckets.col.propensity_min_max_tier"
+            "metadata": "quality_buckets.col.propensity_min_max_tier_test"
           }
         },
         {
@@ -786,7 +786,7 @@
             "text": {
               "expr": {
                 "Literal": {
-                  "Value": "'New Logo Selling âµ Overview'"
+                  "Value": "'New Logo Selling ⁵ Overview'"
                 }
               }
             },

--- a/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/e394af30b0d2fdb8c137/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/5fa311f808ee2894b08a/visuals/e394af30b0d2fdb8c137/visual.json
@@ -26,7 +26,7 @@
                   "Property": "col.propensity_min_max_tier"
                 }
               },
-              "queryRef": "quality_buckets.col.propensity_min_max_tier",
+              "queryRef": "quality_buckets.col.propensity_min_max_tier_test",
               "nativeQueryRef": "Propensity",
               "active": true,
               "displayName": "Propensity"

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/2dc26a6696a8524415ca/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/2dc26a6696a8524415ca/visual.json
@@ -269,7 +269,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_value"
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_value"
           }
         }
       ],
@@ -378,7 +378,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_value"
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_value"
           }
         }
       ],
@@ -427,7 +427,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_value"
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_value"
           }
         }
       ],
@@ -520,7 +520,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_value"
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_value"
           }
         }
       ],
@@ -584,7 +584,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_value"
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_value"
           }
         }
       ],
@@ -612,7 +612,7 @@
                 }
               }
             ],
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_denominator_value",
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_denominator_value",
             "id": "field-fda6916a-f4c0-5c7e-4cee-8c370475e2c3",
             "order": 0
           }
@@ -640,7 +640,7 @@
                 }
               }
             ],
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_nominator_value",
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_nominator_value",
             "id": "field-7c328223-c32e-f500-1993-cba896244c56",
             "order": 0
           }
@@ -656,7 +656,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_nominator_value"
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_nominator_value"
           }
         },
         {
@@ -670,7 +670,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_denominator_value"
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_denominator_value"
           }
         },
         {
@@ -683,7 +683,7 @@
                 }
               }
             ],
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_value",
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_value",
             "id": "field-e8ca89f6-27a4-25f6-b2f8-67e7e24f1356",
             "order": 0
           }
@@ -699,7 +699,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_value"
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_value"
           }
         }
       ],
@@ -727,7 +727,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_nominator_value"
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_nominator_value"
           }
         },
         {
@@ -753,7 +753,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_denominator_value"
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_denominator_value"
           }
         },
         {
@@ -767,7 +767,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_value",
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_value",
             "id": "field-e8ca89f6-27a4-25f6-b2f8-67e7e24f1356"
           }
         }
@@ -784,7 +784,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_nominator_value"
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_nominator_value"
           }
         },
         {
@@ -798,7 +798,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_denominator_value"
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_denominator_value"
           }
         },
         {
@@ -812,7 +812,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_value"
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_value"
           }
         },
         {
@@ -853,7 +853,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_nominator_value"
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_nominator_value"
           }
         },
         {
@@ -867,7 +867,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_denominator_value"
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_denominator_value"
           }
         },
         {
@@ -907,7 +907,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_value",
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_value",
             "id": "field-e8ca89f6-27a4-25f6-b2f8-67e7e24f1356"
           }
         }

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/2fd0869d1e76c8d67b03/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/2fd0869d1e76c8d67b03/visual.json
@@ -311,7 +311,7 @@
                 }
               }
             ],
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_score_w_na_nd"
+            "metadata": "heatmap.meas.heatmap_details_score_w_na_nd"
           }
         }
       ],
@@ -817,7 +817,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_score_w_na_nd"
+            "metadata": "heatmap.meas.heatmap_details_score_w_na_nd"
           }
         },
         {
@@ -1015,7 +1015,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_score_w_na_nd"
+            "metadata": "heatmap.meas.heatmap_details_score_w_na_nd"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/420da10b66100600cc6c/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/420da10b66100600cc6c/visual.json
@@ -233,7 +233,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_kpi1_whats_better"
+            "metadata": "heatmap.meas.heatmap_details_kpi1_whats_better"
           }
         }
       ],
@@ -345,7 +345,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_kpi1_whats_better"
+            "metadata": "heatmap.meas.heatmap_details_kpi1_whats_better"
           }
         }
       ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/445e3d81ea55a9c8435e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/445e3d81ea55a9c8435e/visual.json
@@ -228,7 +228,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_getKPI1_Score_value"
+            "metadata": "heatmap.meas.heatmap_details_getKPI1_Score_value"
           }
         }
       ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/4998da116cc3e01771c8/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/4998da116cc3e01771c8/visual.json
@@ -307,7 +307,7 @@
                 }
               }
             ],
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_score_w_na_nd"
+            "metadata": "heatmap.meas.heatmap_details_score_w_na_nd"
           }
         }
       ],
@@ -847,7 +847,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_score_w_na_nd"
+            "metadata": "heatmap.meas.heatmap_details_score_w_na_nd"
           }
         },
         {
@@ -1201,7 +1201,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_score_w_na_nd"
+            "metadata": "heatmap.meas.heatmap_details_score_w_na_nd"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/737321517e4816292609/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/737321517e4816292609/visual.json
@@ -325,7 +325,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.getHeatmapKPI_AIScore"
+            "metadata": "heatmap.meas.getHeatmapKPI_AIScore"
           }
         }
       ],
@@ -409,7 +409,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.getHeatmapKPI_AIScore"
+            "metadata": "heatmap.meas.getHeatmapKPI_AIScore"
           }
         }
       ],
@@ -514,7 +514,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.getHeatmapKPI_AIScore"
+            "metadata": "heatmap.meas.getHeatmapKPI_AIScore"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/7d83d52d4409a0594927/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/7d83d52d4409a0594927/visual.json
@@ -201,7 +201,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_description"
+            "metadata": "heatmap.meas.heatmap_details_description"
           }
         }
       ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/914036ade00a452a8c05/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/914036ade00a452a8c05/visual.json
@@ -10,22 +10,100 @@
     "tabOrder": 160000
   },
   "visual": {
-    "visualType": "shape",
+    "visualType": "slicer",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "booking_amount_display_mode"
+                    }
+                  },
+                  "Property": "amount_display_mode"
+                }
+              },
+              "queryRef": "booking_amount_display_mode.amount_display_mode",
+              "nativeQueryRef": "amount_display_mode",
+              "active": true
+            }
+          ]
+        }
+      }
+    },
     "objects": {
-      "shape": [
+      "data": [
         {
           "properties": {
-            "tileShape": {
+            "mode": {
               "expr": {
                 "Literal": {
-                  "Value": "'rectangle'"
+                  "Value": "'Dropdown'"
+                }
+              }
+            },
+            "endDate": {
+              "expr": {
+                "Literal": {
+                  "Value": "datetime'2021-12-31T00:00:00'"
                 }
               }
             }
           }
         }
       ],
-      "fill": [
+      "slider": [
+        {
+          "properties": {
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#213E54'"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "date": [
+        {
+          "properties": {
+            "textSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "12D"
+                }
+              }
+            },
+            "fontColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#213E54'"
+                    }
+                  }
+                }
+              }
+            },
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'''Segoe UI'', wf_segoe-ui_normal, helvetica, arial, sans-serif'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "header": [
         {
           "properties": {
             "show": {
@@ -38,20 +116,344 @@
           }
         }
       ],
-      "outline": [
+      "selection": [
         {
           "properties": {
-            "show": {
+            "selectAllCheckboxEnabled": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "singleSelect": {
               "expr": {
                 "Literal": {
                   "Value": "false"
+                }
+              }
+            },
+            "strictSingleSelect": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "general": [
+        {
+          "properties": {
+            "outlineColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": -0.3
+                    }
+                  }
+                }
+              }
+            },
+            "filter": {
+              "filter": {
+                "Version": 2,
+                "From": [
+                  {
+                    "Name": "b",
+                    "Entity": "booking_amount_display_mode",
+                    "Type": 0
+                  }
+                ],
+                "Where": [
+                  {
+                    "Condition": {
+                      "In": {
+                        "Expressions": [
+                          {
+                            "Column": {
+                              "Expression": {
+                                "SourceRef": {
+                                  "Source": "b"
+                                }
+                              },
+                              "Property": "amount_display_mode"
+                            }
+                          }
+                        ],
+                        "Values": [
+                          [
+                            {
+                              "Literal": {
+                                "Value": "'Annual Bookings'"
+                              }
+                            }
+                          ]
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "items": [
+        {
+          "properties": {
+            "fontColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": -0.1
+                    }
+                  }
+                }
+              }
+            },
+            "background": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#2D2E3B'"
+                    }
+                  }
+                }
+              }
+            },
+            "outlineStyle": {
+              "expr": {
+                "Literal": {
+                  "Value": "0D"
+                }
+              }
+            },
+            "textSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11D"
+                }
+              }
+            },
+            "padding": {
+              "expr": {
+                "Literal": {
+                  "Value": "3D"
                 }
               }
             }
           }
         }
       ]
-    }
+    },
+    "visualContainerObjects": {
+      "background": [
+        {
+          "properties": {
+            "transparency": {
+              "expr": {
+                "Literal": {
+                  "Value": "4D"
+                }
+              }
+            },
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "border": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": -0.3
+                    }
+                  }
+                }
+              }
+            },
+            "radius": {
+              "expr": {
+                "Literal": {
+                  "Value": "0D"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "title": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "text": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Booking Amount Display Mode'"
+                }
+              }
+            },
+            "fontColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "background": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#2D2E3B'"
+                    }
+                  }
+                }
+              }
+            },
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'''Segoe UI Semibold'', wf_segoe-ui_semibold, helvetica, arial, sans-serif'"
+                }
+              }
+            },
+            "alignment": {
+              "expr": {
+                "Literal": {
+                  "Value": "'left'"
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "10D"
+                }
+              }
+            },
+            "heading": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Heading4'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "divider": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#689137'"
+                    }
+                  }
+                }
+              }
+            },
+            "width": {
+              "expr": {
+                "Literal": {
+                  "Value": "8D"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "spacing": [
+        {
+          "properties": {
+            "verticalSpacing": {
+              "expr": {
+                "Literal": {
+                  "Value": "3D"
+                }
+              }
+            },
+            "customizeSpacing": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "spaceBelowTitleArea": {
+              "expr": {
+                "Literal": {
+                  "Value": "4D"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "syncGroup": {
+      "groupName": "amount_display_mode",
+      "fieldChanges": true,
+      "filterChanges": true
+    },
+    "drillFilterOtherVisuals": true
   },
   "filterConfig": {
     "filters": [

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/997f33d9d4db0a3d9a34/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/997f33d9d4db0a3d9a34/visual.json
@@ -361,7 +361,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.getHeatmapKPI_AIScore"
+            "metadata": "heatmap.meas.getHeatmapKPI_AIScore"
           }
         }
       ],
@@ -466,7 +466,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.getHeatmapKPI_AIScore"
+            "metadata": "heatmap.meas.getHeatmapKPI_AIScore"
           }
         }
       ],
@@ -590,7 +590,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.getHeatmapKPI_AIScore"
+            "metadata": "heatmap.meas.getHeatmapKPI_AIScore"
           }
         }
       ],
@@ -606,7 +606,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.getHeatmapKPI_AIScore"
+            "metadata": "heatmap.meas.getHeatmapKPI_AIScore"
           }
         }
       ],
@@ -636,7 +636,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.getHeatmapKPI_AIScore"
+            "metadata": "heatmap.meas.getHeatmapKPI_AIScore"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/adfcc0e03cca4409e193/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/adfcc0e03cca4409e193/visual.json
@@ -226,7 +226,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_kpi2_whats_better"
+            "metadata": "heatmap.meas.heatmap_details_kpi2_whats_better"
           }
         }
       ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/bfef4ca3a09aa207b0b1/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/bfef4ca3a09aa207b0b1/visual.json
@@ -27,8 +27,8 @@
                 }
               },
               "queryRef": "heatmap.meas.heatmap_details_kpi1_long_def",
-              "nativeQueryRef": "KPI Value 1 - What is Measured â´",
-              "displayName": "KPI Value 1 - What is Measured â´"
+              "nativeQueryRef": "KPI Value 1 - What is Measured ⁴",
+              "displayName": "KPI Value 1 - What is Measured ⁴"
             }
           ]
         }
@@ -208,7 +208,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_kpi1_long_def"
+            "metadata": "heatmap.meas.heatmap_details_kpi1_long_def"
           }
         }
       ],
@@ -298,7 +298,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_kpi1_long_def"
+            "metadata": "heatmap.meas.heatmap_details_kpi1_long_def"
           }
         }
       ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/ccfb8963ae004bb13310/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/ccfb8963ae004bb13310/visual.json
@@ -460,7 +460,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_kpi1_min_value"
+            "metadata": "heatmap.meas.heatmap_details_kpi1_min_value"
           }
         }
       ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/d2f7663426102a006113/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/d2f7663426102a006113/visual.json
@@ -206,7 +206,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_hypothesis_confirmed"
+            "metadata": "heatmap.meas.heatmap_details_hypothesis_confirmed"
           }
         },
         {
@@ -232,7 +232,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.combined_score_top_w_text"
+            "metadata": "heatmap.meas.combined_score_top_w_text"
           }
         },
         {
@@ -245,7 +245,7 @@
                 }
               }
             ],
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_hypothesis_confirmed"
+            "metadata": "heatmap.meas.heatmap_details_hypothesis_confirmed"
           }
         }
       ],
@@ -301,7 +301,7 @@
             "text": {
               "expr": {
                 "Literal": {
-                  "Value": "'Hypothesis Score Trend Â²'"
+                  "Value": "'Hypothesis Score Trend ²'"
                 }
               }
             },
@@ -333,7 +333,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.combined_score_top_w_text"
+            "metadata": "heatmap.meas.combined_score_top_w_text"
           }
         },
         {
@@ -373,7 +373,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_hypothesis_confirmed"
+            "metadata": "heatmap.meas.heatmap_details_hypothesis_confirmed"
           }
         }
       ],
@@ -474,7 +474,7 @@
                 }
               }
             ],
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_hypothesis_confirmed"
+            "metadata": "heatmap.meas.heatmap_details_hypothesis_confirmed"
           }
         }
       ],
@@ -560,7 +560,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_hypothesis_confirmed"
+            "metadata": "heatmap.meas.heatmap_details_hypothesis_confirmed"
           }
         }
       ],
@@ -599,7 +599,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.combined_score_top_w_text"
+            "metadata": "heatmap.meas.combined_score_top_w_text"
           }
         },
         {
@@ -613,7 +613,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_hypothesis_confirmed"
+            "metadata": "heatmap.meas.heatmap_details_hypothesis_confirmed"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/dcaf5bbf423dd02c5053/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/7ccdebfd672051e0799d/visuals/dcaf5bbf423dd02c5053/visual.json
@@ -289,7 +289,7 @@
           "From": [
             {
               "Name": "l",
-              "Entity": "cal_end_dates",
+              "Entity": "LocalDateTable_d9cd643e-7eb2-4078-b7d4-6261fea9cd66",
               "Type": 0
             }
           ],
@@ -307,7 +307,7 @@
                                 "Source": "l"
                               }
                             },
-                            "Property": "Date"
+                            "Property": "Quarter"
                           }
                         }
                       ],
@@ -369,10 +369,10 @@
                           "Column": {
                             "Expression": {
                               "SourceRef": {
-                                "Entity": "cal_end_dates"
+                                "Entity": "LocalDateTable_d9cd643e-7eb2-4078-b7d4-6261fea9cd66"
                               }
                             },
-                            "Property": "Date"
+                            "Property": "Quarter"
                           }
                         }
                       }

--- a/powerbi/src/Strategy Report.Report/definition/pages/8e940fbf596ebfc5deba/visuals/c7a77c7232c308b1b649/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/8e940fbf596ebfc5deba/visuals/c7a77c7232c308b1b649/visual.json
@@ -23,10 +23,10 @@
                       "Entity": "users"
                     }
                   },
-                  "Property": "trueai_user_role_function"
+                  "Property": "col.user_role_function"
                 }
               },
-              "queryRef": "users.trueai_user_role_function",
+              "queryRef": "users.col.user_role_function",
               "active": true
             }
           ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/9613185c0b5d01cc2e8b/visuals/111a664553e1544486b8/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9613185c0b5d01cc2e8b/visuals/111a664553e1544486b8/visual.json
@@ -87,8 +87,8 @@
                 }
               },
               "queryRef": "heatmap.meas.heatmap_details_score_new",
-              "nativeQueryRef": "Heatmap Score Â²",
-              "displayName": "Heatmap Score Â²"
+              "nativeQueryRef": "Heatmap Score ²",
+              "displayName": "Heatmap Score ²"
             },
             {
               "field": {
@@ -102,8 +102,8 @@
                 }
               },
               "queryRef": "heatmap.meas.kpi_combined_score",
-              "nativeQueryRef": "Change Â³",
-              "displayName": "Change Â³",
+              "nativeQueryRef": "Change ³",
+              "displayName": "Change ³",
               "format": "0"
             },
             {
@@ -133,8 +133,8 @@
                 }
               },
               "queryRef": "heatmap.meas.getHeatmapKPI_AIScore",
-              "nativeQueryRef": "Data Trust Level â´",
-              "displayName": "Data Trust Level â´"
+              "nativeQueryRef": "Data Trust Level ⁴",
+              "displayName": "Data Trust Level ⁴"
             }
           ]
         }
@@ -170,7 +170,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.hypothesis_is_confirmed"
+            "metadata": "heatmap.meas.hypothesis_is_confirmed"
           }
         },
         {
@@ -184,7 +184,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.getHeatmapKPI_AIScore"
+            "metadata": "heatmap.meas.getHeatmapKPI_AIScore"
           }
         },
         {
@@ -212,7 +212,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.kpi_combined_score"
+            "metadata": "heatmap.meas.kpi_combined_score"
           }
         },
         {
@@ -226,7 +226,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_score_new"
+            "metadata": "heatmap.meas.heatmap_details_score_new"
           }
         },
         {
@@ -609,7 +609,7 @@
                 }
               }
             ],
-            "metadata": "metadata_heatmap_items.meas.hypothesis_is_confirmed"
+            "metadata": "heatmap.meas.hypothesis_is_confirmed"
           }
         },
         {
@@ -1013,7 +1013,7 @@
                 }
               }
             ],
-            "metadata": "metadata_heatmap_items.meas.getHeatmapKPI_AIScore"
+            "metadata": "heatmap.meas.getHeatmapKPI_AIScore"
           }
         },
         {
@@ -1307,7 +1307,7 @@
                 }
               }
             ],
-            "metadata": "metadata_heatmap_items.meas.kpi_combined_score"
+            "metadata": "heatmap.meas.kpi_combined_score"
           }
         },
         {
@@ -1588,7 +1588,7 @@
                 }
               }
             ],
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_score_new"
+            "metadata": "heatmap.meas.heatmap_details_score_new"
           }
         }
       ],
@@ -1764,7 +1764,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.hypothesis_is_confirmed"
+            "metadata": "heatmap.meas.hypothesis_is_confirmed"
           }
         },
         {
@@ -1815,7 +1815,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.getHeatmapKPI_AIScore"
+            "metadata": "heatmap.meas.getHeatmapKPI_AIScore"
           }
         },
         {
@@ -1885,7 +1885,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.kpi_combined_score"
+            "metadata": "heatmap.meas.kpi_combined_score"
           }
         },
         {
@@ -1899,7 +1899,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_details_score_new"
+            "metadata": "heatmap.meas.heatmap_details_score_new"
           }
         }
       ]

--- a/powerbi/src/Strategy Report.Report/definition/pages/9613185c0b5d01cc2e8b/visuals/2b063a66112b9b0b75de/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9613185c0b5d01cc2e8b/visuals/2b063a66112b9b0b75de/visual.json
@@ -10,22 +10,100 @@
     "tabOrder": 79000
   },
   "visual": {
-    "visualType": "shape",
+    "visualType": "slicer",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "booking_amount_display_mode"
+                    }
+                  },
+                  "Property": "amount_display_mode"
+                }
+              },
+              "queryRef": "booking_amount_display_mode.amount_display_mode",
+              "nativeQueryRef": "amount_display_mode",
+              "active": true
+            }
+          ]
+        }
+      }
+    },
     "objects": {
-      "shape": [
+      "data": [
         {
           "properties": {
-            "tileShape": {
+            "mode": {
               "expr": {
                 "Literal": {
-                  "Value": "'rectangle'"
+                  "Value": "'Dropdown'"
+                }
+              }
+            },
+            "endDate": {
+              "expr": {
+                "Literal": {
+                  "Value": "datetime'2021-12-31T00:00:00'"
                 }
               }
             }
           }
         }
       ],
-      "fill": [
+      "slider": [
+        {
+          "properties": {
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#213E54'"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "date": [
+        {
+          "properties": {
+            "textSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "12D"
+                }
+              }
+            },
+            "fontColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#213E54'"
+                    }
+                  }
+                }
+              }
+            },
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'''Segoe UI'', wf_segoe-ui_normal, helvetica, arial, sans-serif'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "header": [
         {
           "properties": {
             "show": {
@@ -38,20 +116,344 @@
           }
         }
       ],
-      "outline": [
+      "selection": [
         {
           "properties": {
-            "show": {
+            "selectAllCheckboxEnabled": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "singleSelect": {
               "expr": {
                 "Literal": {
                   "Value": "false"
+                }
+              }
+            },
+            "strictSingleSelect": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "general": [
+        {
+          "properties": {
+            "outlineColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": -0.3
+                    }
+                  }
+                }
+              }
+            },
+            "filter": {
+              "filter": {
+                "Version": 2,
+                "From": [
+                  {
+                    "Name": "b",
+                    "Entity": "booking_amount_display_mode",
+                    "Type": 0
+                  }
+                ],
+                "Where": [
+                  {
+                    "Condition": {
+                      "In": {
+                        "Expressions": [
+                          {
+                            "Column": {
+                              "Expression": {
+                                "SourceRef": {
+                                  "Source": "b"
+                                }
+                              },
+                              "Property": "amount_display_mode"
+                            }
+                          }
+                        ],
+                        "Values": [
+                          [
+                            {
+                              "Literal": {
+                                "Value": "'Annual Bookings'"
+                              }
+                            }
+                          ]
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "items": [
+        {
+          "properties": {
+            "fontColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": -0.1
+                    }
+                  }
+                }
+              }
+            },
+            "background": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#2D2E3B'"
+                    }
+                  }
+                }
+              }
+            },
+            "outlineStyle": {
+              "expr": {
+                "Literal": {
+                  "Value": "0D"
+                }
+              }
+            },
+            "textSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11D"
+                }
+              }
+            },
+            "padding": {
+              "expr": {
+                "Literal": {
+                  "Value": "3D"
                 }
               }
             }
           }
         }
       ]
-    }
+    },
+    "visualContainerObjects": {
+      "background": [
+        {
+          "properties": {
+            "transparency": {
+              "expr": {
+                "Literal": {
+                  "Value": "4D"
+                }
+              }
+            },
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "border": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": -0.3
+                    }
+                  }
+                }
+              }
+            },
+            "radius": {
+              "expr": {
+                "Literal": {
+                  "Value": "0D"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "title": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "text": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Booking Amount Display Mode'"
+                }
+              }
+            },
+            "fontColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "background": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#2D2E3B'"
+                    }
+                  }
+                }
+              }
+            },
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'''Segoe UI Semibold'', wf_segoe-ui_semibold, helvetica, arial, sans-serif'"
+                }
+              }
+            },
+            "alignment": {
+              "expr": {
+                "Literal": {
+                  "Value": "'left'"
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "10D"
+                }
+              }
+            },
+            "heading": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Heading4'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "divider": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#689137'"
+                    }
+                  }
+                }
+              }
+            },
+            "width": {
+              "expr": {
+                "Literal": {
+                  "Value": "8D"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "spacing": [
+        {
+          "properties": {
+            "verticalSpacing": {
+              "expr": {
+                "Literal": {
+                  "Value": "3D"
+                }
+              }
+            },
+            "customizeSpacing": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "spaceBelowTitleArea": {
+              "expr": {
+                "Literal": {
+                  "Value": "4D"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "syncGroup": {
+      "groupName": "amount_display_mode",
+      "fieldChanges": true,
+      "filterChanges": true
+    },
+    "drillFilterOtherVisuals": true
   },
   "filterConfig": {
     "filters": [

--- a/powerbi/src/Strategy Report.Report/definition/pages/9613185c0b5d01cc2e8b/visuals/9233f02561b181b42c90/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/9613185c0b5d01cc2e8b/visuals/9233f02561b181b42c90/visual.json
@@ -253,7 +253,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_booking_growth_rate"
+            "metadata": "heatmap.meas.heatmap_booking_growth_rate"
           }
         },
         {
@@ -521,7 +521,7 @@
                 }
               }
             ],
-            "metadata": "metadata_heatmap_items.meas.heatmap_booking_growth_rate"
+            "metadata": "heatmap.meas.heatmap_booking_growth_rate"
           }
         }
       ],
@@ -587,7 +587,7 @@
             }
           },
           "selector": {
-            "metadata": "metadata_heatmap_items.meas.heatmap_booking_growth_rate"
+            "metadata": "heatmap.meas.heatmap_booking_growth_rate"
           }
         },
         {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/de1a61d8beea0101d790/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/de1a61d8beea0101d790/visual.json
@@ -240,7 +240,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_new_hires"
+            "metadata": "data_logs.meas.data_logs_user_new_hires"
           }
         },
         {
@@ -443,7 +443,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_new_hires"
+            "metadata": "data_logs.meas.data_logs_user_new_hires"
           }
         },
         {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/e3a0478db81f8b6e19d5/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/e3a0478db81f8b6e19d5/visual.json
@@ -240,7 +240,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_new_hires"
+            "metadata": "data_logs.meas.data_logs_user_new_hires"
           }
         },
         {
@@ -443,7 +443,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_new_hires"
+            "metadata": "data_logs.meas.data_logs_user_new_hires"
           }
         },
         {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/f8a4b49f906ac48b2ffd/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection03ed78b54ee00ab0ed5d/visuals/f8a4b49f906ac48b2ffd/visual.json
@@ -240,7 +240,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_new_hires"
+            "metadata": "data_logs.meas.data_logs_user_new_hires"
           }
         },
         {
@@ -443,7 +443,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_new_hires"
+            "metadata": "data_logs.meas.data_logs_user_new_hires"
           }
         },
         {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/461d8a470d40e19d1256/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/461d8a470d40e19d1256/visual.json
@@ -167,10 +167,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -198,10 +198,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -229,10 +229,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -260,10 +260,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -291,10 +291,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -322,10 +322,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -353,10 +353,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/5fe9a408556a476ad134/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/5fe9a408556a476ad134/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Date Year1",
               "active": true
             }
@@ -154,7 +154,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Name": "VariaciÃ³n",
+                        "Name": "Variación",
                         "Property": "Date"
                       }
                     },
@@ -635,7 +635,7 @@
                     "Entity": "users_history"
                   }
                 },
-                "Property": "ci_time_alloc_existing_customer_selling"
+                "Property": "ci_time_alloc_upselling"
               }
             },
             "Function": 1
@@ -767,7 +767,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Date"
                   }
                 },
@@ -793,7 +793,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Date"
                   }
                 },
@@ -820,7 +820,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Date"
                   }
                 },
@@ -847,7 +847,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/ee3a987659ab7ce7d108/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection12f673ea22d93d640fb4/visuals/ee3a987659ab7ce7d108/visual.json
@@ -1699,10 +1699,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "ssr_history"
+                    "Entity": "users_history"
                   }
                 },
-                "Property": "vi_value_repeat"
+                "Property": "vi_value_received_total"
               }
             },
             "Function": 0
@@ -1735,10 +1735,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "ssr_history"
+                    "Entity": "users_history"
                   }
                 },
-                "Property": "vi_value_created"
+                "Property": "vi_value_created_selling"
               }
             },
             "Function": 0

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/ec5d55420260706516c3/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection5f1aac2b759aead4e65f/visuals/ec5d55420260706516c3/visual.json
@@ -10,22 +10,100 @@
     "tabOrder": 73000
   },
   "visual": {
-    "visualType": "shape",
+    "visualType": "slicer",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "booking_amount_display_mode"
+                    }
+                  },
+                  "Property": "amount_display_mode"
+                }
+              },
+              "queryRef": "booking_amount_display_mode.amount_display_mode",
+              "nativeQueryRef": "amount_display_mode",
+              "active": true
+            }
+          ]
+        }
+      }
+    },
     "objects": {
-      "shape": [
+      "data": [
         {
           "properties": {
-            "tileShape": {
+            "mode": {
               "expr": {
                 "Literal": {
-                  "Value": "'rectangle'"
+                  "Value": "'Dropdown'"
+                }
+              }
+            },
+            "endDate": {
+              "expr": {
+                "Literal": {
+                  "Value": "datetime'2021-12-31T00:00:00'"
                 }
               }
             }
           }
         }
       ],
-      "fill": [
+      "slider": [
+        {
+          "properties": {
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#213E54'"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "date": [
+        {
+          "properties": {
+            "textSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "12D"
+                }
+              }
+            },
+            "fontColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#213E54'"
+                    }
+                  }
+                }
+              }
+            },
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'''Segoe UI'', wf_segoe-ui_normal, helvetica, arial, sans-serif'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "header": [
         {
           "properties": {
             "show": {
@@ -38,20 +116,344 @@
           }
         }
       ],
-      "outline": [
+      "selection": [
         {
           "properties": {
-            "show": {
+            "selectAllCheckboxEnabled": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "singleSelect": {
               "expr": {
                 "Literal": {
                   "Value": "false"
+                }
+              }
+            },
+            "strictSingleSelect": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "general": [
+        {
+          "properties": {
+            "outlineColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": -0.3
+                    }
+                  }
+                }
+              }
+            },
+            "filter": {
+              "filter": {
+                "Version": 2,
+                "From": [
+                  {
+                    "Name": "b",
+                    "Entity": "booking_amount_display_mode",
+                    "Type": 0
+                  }
+                ],
+                "Where": [
+                  {
+                    "Condition": {
+                      "In": {
+                        "Expressions": [
+                          {
+                            "Column": {
+                              "Expression": {
+                                "SourceRef": {
+                                  "Source": "b"
+                                }
+                              },
+                              "Property": "amount_display_mode"
+                            }
+                          }
+                        ],
+                        "Values": [
+                          [
+                            {
+                              "Literal": {
+                                "Value": "'Annual Bookings'"
+                              }
+                            }
+                          ]
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "items": [
+        {
+          "properties": {
+            "fontColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": -0.1
+                    }
+                  }
+                }
+              }
+            },
+            "background": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#2D2E3B'"
+                    }
+                  }
+                }
+              }
+            },
+            "outlineStyle": {
+              "expr": {
+                "Literal": {
+                  "Value": "0D"
+                }
+              }
+            },
+            "textSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11D"
+                }
+              }
+            },
+            "padding": {
+              "expr": {
+                "Literal": {
+                  "Value": "3D"
                 }
               }
             }
           }
         }
       ]
-    }
+    },
+    "visualContainerObjects": {
+      "background": [
+        {
+          "properties": {
+            "transparency": {
+              "expr": {
+                "Literal": {
+                  "Value": "4D"
+                }
+              }
+            },
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "border": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": -0.3
+                    }
+                  }
+                }
+              }
+            },
+            "radius": {
+              "expr": {
+                "Literal": {
+                  "Value": "0D"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "title": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "text": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Booking Amount Display Mode'"
+                }
+              }
+            },
+            "fontColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "background": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#2D2E3B'"
+                    }
+                  }
+                }
+              }
+            },
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'''Segoe UI Semibold'', wf_segoe-ui_semibold, helvetica, arial, sans-serif'"
+                }
+              }
+            },
+            "alignment": {
+              "expr": {
+                "Literal": {
+                  "Value": "'left'"
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "10D"
+                }
+              }
+            },
+            "heading": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Heading4'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "divider": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#689137'"
+                    }
+                  }
+                }
+              }
+            },
+            "width": {
+              "expr": {
+                "Literal": {
+                  "Value": "8D"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "spacing": [
+        {
+          "properties": {
+            "verticalSpacing": {
+              "expr": {
+                "Literal": {
+                  "Value": "3D"
+                }
+              }
+            },
+            "customizeSpacing": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "spaceBelowTitleArea": {
+              "expr": {
+                "Literal": {
+                  "Value": "4D"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "syncGroup": {
+      "groupName": "amount_display_mode",
+      "fieldChanges": true,
+      "filterChanges": true
+    },
+    "drillFilterOtherVisuals": true
   },
   "filterConfig": {
     "filters": [

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/bf444daba43b128ae0b4/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7536531a564a0674a972/visuals/bf444daba43b128ae0b4/visual.json
@@ -10,22 +10,100 @@
     "tabOrder": 75000
   },
   "visual": {
-    "visualType": "shape",
+    "visualType": "slicer",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "booking_amount_display_mode"
+                    }
+                  },
+                  "Property": "amount_display_mode"
+                }
+              },
+              "queryRef": "booking_amount_display_mode.amount_display_mode",
+              "nativeQueryRef": "amount_display_mode",
+              "active": true
+            }
+          ]
+        }
+      }
+    },
     "objects": {
-      "shape": [
+      "data": [
         {
           "properties": {
-            "tileShape": {
+            "mode": {
               "expr": {
                 "Literal": {
-                  "Value": "'rectangle'"
+                  "Value": "'Dropdown'"
+                }
+              }
+            },
+            "endDate": {
+              "expr": {
+                "Literal": {
+                  "Value": "datetime'2021-12-31T00:00:00'"
                 }
               }
             }
           }
         }
       ],
-      "fill": [
+      "slider": [
+        {
+          "properties": {
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#213E54'"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "date": [
+        {
+          "properties": {
+            "textSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "12D"
+                }
+              }
+            },
+            "fontColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#213E54'"
+                    }
+                  }
+                }
+              }
+            },
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'''Segoe UI'', wf_segoe-ui_normal, helvetica, arial, sans-serif'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "header": [
         {
           "properties": {
             "show": {
@@ -38,20 +116,344 @@
           }
         }
       ],
-      "outline": [
+      "selection": [
         {
           "properties": {
-            "show": {
+            "selectAllCheckboxEnabled": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "singleSelect": {
               "expr": {
                 "Literal": {
                   "Value": "false"
+                }
+              }
+            },
+            "strictSingleSelect": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "general": [
+        {
+          "properties": {
+            "outlineColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": -0.3
+                    }
+                  }
+                }
+              }
+            },
+            "filter": {
+              "filter": {
+                "Version": 2,
+                "From": [
+                  {
+                    "Name": "b",
+                    "Entity": "booking_amount_display_mode",
+                    "Type": 0
+                  }
+                ],
+                "Where": [
+                  {
+                    "Condition": {
+                      "In": {
+                        "Expressions": [
+                          {
+                            "Column": {
+                              "Expression": {
+                                "SourceRef": {
+                                  "Source": "b"
+                                }
+                              },
+                              "Property": "amount_display_mode"
+                            }
+                          }
+                        ],
+                        "Values": [
+                          [
+                            {
+                              "Literal": {
+                                "Value": "'Annual Bookings'"
+                              }
+                            }
+                          ]
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "items": [
+        {
+          "properties": {
+            "fontColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": -0.1
+                    }
+                  }
+                }
+              }
+            },
+            "background": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#2D2E3B'"
+                    }
+                  }
+                }
+              }
+            },
+            "outlineStyle": {
+              "expr": {
+                "Literal": {
+                  "Value": "0D"
+                }
+              }
+            },
+            "textSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11D"
+                }
+              }
+            },
+            "padding": {
+              "expr": {
+                "Literal": {
+                  "Value": "3D"
                 }
               }
             }
           }
         }
       ]
-    }
+    },
+    "visualContainerObjects": {
+      "background": [
+        {
+          "properties": {
+            "transparency": {
+              "expr": {
+                "Literal": {
+                  "Value": "4D"
+                }
+              }
+            },
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "border": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": -0.3
+                    }
+                  }
+                }
+              }
+            },
+            "radius": {
+              "expr": {
+                "Literal": {
+                  "Value": "0D"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "title": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "text": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Booking Amount Display Mode'"
+                }
+              }
+            },
+            "fontColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "background": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#2D2E3B'"
+                    }
+                  }
+                }
+              }
+            },
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'''Segoe UI Semibold'', wf_segoe-ui_semibold, helvetica, arial, sans-serif'"
+                }
+              }
+            },
+            "alignment": {
+              "expr": {
+                "Literal": {
+                  "Value": "'left'"
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "10D"
+                }
+              }
+            },
+            "heading": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Heading4'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "divider": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#689137'"
+                    }
+                  }
+                }
+              }
+            },
+            "width": {
+              "expr": {
+                "Literal": {
+                  "Value": "8D"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "spacing": [
+        {
+          "properties": {
+            "verticalSpacing": {
+              "expr": {
+                "Literal": {
+                  "Value": "3D"
+                }
+              }
+            },
+            "customizeSpacing": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "spaceBelowTitleArea": {
+              "expr": {
+                "Literal": {
+                  "Value": "4D"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "syncGroup": {
+      "groupName": "amount_display_mode",
+      "fieldChanges": true,
+      "filterChanges": true
+    },
+    "drillFilterOtherVisuals": true
   },
   "filterConfig": {
     "filters": [

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/15f4f1453c4a277030c9/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection794587a77f471f93741e/visuals/15f4f1453c4a277030c9/visual.json
@@ -45,7 +45,7 @@
                   "Property": "meas.ssr_history_rev_starting_count"
                 }
               },
-              "queryRef": "ssr_history.meas.ssr_history_rev_starting_count",
+              "queryRef": "ssr_history.meas.ssr_history_rev_starting_count1",
               "displayName": "# Accounts (BOY)"
             },
             {
@@ -200,7 +200,7 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_rev_churned_count",
-              "displayName": "# Churned Accounts Â¹"
+              "displayName": "# Churned Accounts ¹"
             },
             {
               "field": {
@@ -255,7 +255,7 @@
                   "Property": "meas.ssr_history_rev_ending_count"
                 }
               },
-              "queryRef": "ssr_history.meas.ssr_history_rev_ending_count",
+              "queryRef": "ssr_history.meas.ssr_history_rev_starting_count",
               "displayName": "# Accounts (EOY)"
             }
           ]
@@ -926,7 +926,7 @@
             }
           },
           "selector": {
-            "metadata": "ssr_history.meas.ssr_history_rev_starting_count"
+            "metadata": "ssr_history.meas.ssr_history_rev_starting_count1"
           }
         },
         {
@@ -1550,7 +1550,7 @@
             }
           },
           "selector": {
-            "metadata": "ssr_history.meas.ssr_history_rev_starting_count"
+            "metadata": "ssr_history.meas.ssr_history_rev_starting_count1"
           }
         },
         {
@@ -1650,7 +1650,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -1687,7 +1687,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/29374b987f01a43cc933/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection7d2b934ae82c9dbed878/visuals/29374b987f01a43cc933/visual.json
@@ -343,10 +343,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_f142aaad-c029-4445-8110-9fdfbb1cd5b6"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -385,10 +385,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_f142aaad-c029-4445-8110-9fdfbb1cd5b6"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -427,10 +427,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_d9cd643e-7eb2-4078-b7d4-6261fea9cd66"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -469,10 +469,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_d9cd643e-7eb2-4078-b7d4-6261fea9cd66"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -511,10 +511,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_d9cd643e-7eb2-4078-b7d4-6261fea9cd66"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -553,10 +553,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_d9cd643e-7eb2-4078-b7d4-6261fea9cd66"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/030605119d517f4728df/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/030605119d517f4728df/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year1",
               "active": true
             }
@@ -569,7 +569,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -606,7 +606,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -640,10 +640,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -677,10 +677,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -714,10 +714,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -751,10 +751,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -788,10 +788,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -825,10 +825,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1263,7 +1263,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/095d6065c61ee17e99a2/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/095d6065c61ee17e99a2/visual.json
@@ -10,22 +10,100 @@
     "tabOrder": 126000
   },
   "visual": {
-    "visualType": "shape",
+    "visualType": "slicer",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "booking_amount_display_mode"
+                    }
+                  },
+                  "Property": "amount_display_mode"
+                }
+              },
+              "queryRef": "booking_amount_display_mode.amount_display_mode",
+              "nativeQueryRef": "amount_display_mode",
+              "active": true
+            }
+          ]
+        }
+      }
+    },
     "objects": {
-      "shape": [
+      "data": [
         {
           "properties": {
-            "tileShape": {
+            "mode": {
               "expr": {
                 "Literal": {
-                  "Value": "'rectangle'"
+                  "Value": "'Dropdown'"
+                }
+              }
+            },
+            "endDate": {
+              "expr": {
+                "Literal": {
+                  "Value": "datetime'2021-12-31T00:00:00'"
                 }
               }
             }
           }
         }
       ],
-      "fill": [
+      "slider": [
+        {
+          "properties": {
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#213E54'"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "date": [
+        {
+          "properties": {
+            "textSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "12D"
+                }
+              }
+            },
+            "fontColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#213E54'"
+                    }
+                  }
+                }
+              }
+            },
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'''Segoe UI'', wf_segoe-ui_normal, helvetica, arial, sans-serif'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "header": [
         {
           "properties": {
             "show": {
@@ -38,20 +116,344 @@
           }
         }
       ],
-      "outline": [
+      "selection": [
         {
           "properties": {
-            "show": {
+            "selectAllCheckboxEnabled": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "singleSelect": {
               "expr": {
                 "Literal": {
                   "Value": "false"
+                }
+              }
+            },
+            "strictSingleSelect": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "general": [
+        {
+          "properties": {
+            "outlineColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": -0.3
+                    }
+                  }
+                }
+              }
+            },
+            "filter": {
+              "filter": {
+                "Version": 2,
+                "From": [
+                  {
+                    "Name": "b",
+                    "Entity": "booking_amount_display_mode",
+                    "Type": 0
+                  }
+                ],
+                "Where": [
+                  {
+                    "Condition": {
+                      "In": {
+                        "Expressions": [
+                          {
+                            "Column": {
+                              "Expression": {
+                                "SourceRef": {
+                                  "Source": "b"
+                                }
+                              },
+                              "Property": "amount_display_mode"
+                            }
+                          }
+                        ],
+                        "Values": [
+                          [
+                            {
+                              "Literal": {
+                                "Value": "'Annual Bookings'"
+                              }
+                            }
+                          ]
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "items": [
+        {
+          "properties": {
+            "fontColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": -0.1
+                    }
+                  }
+                }
+              }
+            },
+            "background": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#2D2E3B'"
+                    }
+                  }
+                }
+              }
+            },
+            "outlineStyle": {
+              "expr": {
+                "Literal": {
+                  "Value": "0D"
+                }
+              }
+            },
+            "textSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11D"
+                }
+              }
+            },
+            "padding": {
+              "expr": {
+                "Literal": {
+                  "Value": "3D"
                 }
               }
             }
           }
         }
       ]
-    }
+    },
+    "visualContainerObjects": {
+      "background": [
+        {
+          "properties": {
+            "transparency": {
+              "expr": {
+                "Literal": {
+                  "Value": "4D"
+                }
+              }
+            },
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "border": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": -0.3
+                    }
+                  }
+                }
+              }
+            },
+            "radius": {
+              "expr": {
+                "Literal": {
+                  "Value": "0D"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "title": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "text": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Booking Amount Display Mode'"
+                }
+              }
+            },
+            "fontColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "background": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#2D2E3B'"
+                    }
+                  }
+                }
+              }
+            },
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'''Segoe UI Semibold'', wf_segoe-ui_semibold, helvetica, arial, sans-serif'"
+                }
+              }
+            },
+            "alignment": {
+              "expr": {
+                "Literal": {
+                  "Value": "'left'"
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "10D"
+                }
+              }
+            },
+            "heading": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Heading4'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "divider": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#689137'"
+                    }
+                  }
+                }
+              }
+            },
+            "width": {
+              "expr": {
+                "Literal": {
+                  "Value": "8D"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "spacing": [
+        {
+          "properties": {
+            "verticalSpacing": {
+              "expr": {
+                "Literal": {
+                  "Value": "3D"
+                }
+              }
+            },
+            "customizeSpacing": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "spaceBelowTitleArea": {
+              "expr": {
+                "Literal": {
+                  "Value": "4D"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "syncGroup": {
+      "groupName": "amount_display_mode",
+      "fieldChanges": true,
+      "filterChanges": true
+    },
+    "drillFilterOtherVisuals": true
   },
   "filterConfig": {
     "filters": [

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/16df1eb7a4eb5c41bd92/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/16df1eb7a4eb5c41bd92/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year1",
               "active": true
             }
@@ -569,7 +569,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -606,7 +606,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -640,10 +640,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -677,10 +677,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -714,10 +714,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -751,10 +751,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -788,10 +788,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -825,10 +825,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1263,7 +1263,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/4417744090cd61e314e4/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/4417744090cd61e314e4/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year1",
               "active": true
             }
@@ -554,7 +554,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -591,7 +591,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -625,10 +625,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -662,10 +662,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -699,10 +699,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -736,10 +736,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -773,10 +773,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -810,10 +810,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1219,7 +1219,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/4dd654a6328495c68b4d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/4dd654a6328495c68b4d/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year1",
               "active": true
             }
@@ -554,7 +554,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -591,7 +591,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -625,10 +625,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -662,10 +662,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -699,10 +699,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -736,10 +736,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -773,10 +773,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -810,10 +810,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1212,7 +1212,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/6271c1cbf28b61312310/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/6271c1cbf28b61312310/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year1",
               "active": true
             },
@@ -53,7 +53,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -63,7 +63,7 @@
                   "Level": "Quarter"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Quarter",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Quarter",
               "nativeQueryRef": "Fiscal Date Quarter1",
               "active": true
             }
@@ -132,7 +132,7 @@
                             "Entity": "users_history"
                           }
                         },
-                        "Property": "col.user.user_role_function"
+                        "Property": "user.user_role"
                       }
                     },
                     "Right": {
@@ -462,7 +462,7 @@
             "text": {
               "expr": {
                 "Literal": {
-                  "Value": "'Conversion Rate (DI) Â²'"
+                  "Value": "'Conversion Rate (DI) ²'"
                 }
               }
             },
@@ -632,7 +632,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },
@@ -658,7 +658,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/6b907f75ef279e7c4d39/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/6b907f75ef279e7c4d39/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year",
               "active": true
             },
@@ -53,7 +53,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -63,7 +63,7 @@
                   "Level": "Quarter"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Quarter",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Quarter",
               "nativeQueryRef": "Fiscal Date Quarter",
               "active": false
             }
@@ -132,7 +132,7 @@
                             "Entity": "users_history"
                           }
                         },
-                        "Property": "col.user.user_role_function"
+                        "Property": "user.user_role"
                       }
                     },
                     "Right": {
@@ -462,7 +462,7 @@
             "text": {
               "expr": {
                 "Literal": {
-                  "Value": "'Win Rate (DI) Â²'"
+                  "Value": "'Win Rate (DI) ²'"
                 }
               }
             },
@@ -664,7 +664,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },
@@ -690,7 +690,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/7298d05faf497ffc85a6/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/7298d05faf497ffc85a6/visual.json
@@ -471,10 +471,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -508,10 +508,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -545,10 +545,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -582,10 +582,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/84d7daf283109237a774/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/84d7daf283109237a774/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year1",
               "active": true
             }
@@ -62,7 +62,7 @@
                 }
               },
               "queryRef": "Sum(ssr_history.step_success_prob)",
-              "displayName": "Predicted Success (DI) Â²"
+              "displayName": "Predicted Success (DI) ²"
             },
             {
               "field": {
@@ -76,8 +76,8 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_duration_hrs_existing_customer_selling_sales_process_step",
-              "nativeQueryRef": "Tot. Time Spent Existing Cust. Selling Â³",
-              "displayName": "Tot. Time Spent Existing Cust. Selling Â³"
+              "nativeQueryRef": "Tot. Time Spent Existing Cust. Selling ³",
+              "displayName": "Tot. Time Spent Existing Cust. Selling ³"
             },
             {
               "field": {
@@ -91,7 +91,7 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_duration_hrs_per_step",
-              "displayName": "Adj. Time Spent per Attempt (CI) Â³"
+              "displayName": "Adj. Time Spent per Attempt (CI) ³"
             },
             {
               "field": {
@@ -105,7 +105,7 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_duration_hrs_rep_week",
-              "displayName": "Avg. Time Spent per Rep / Week Â³"
+              "displayName": "Avg. Time Spent per Rep / Week ³"
             },
             {
               "field": {
@@ -119,8 +119,8 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_vi_value_created",
-              "nativeQueryRef": "Value Created (VI) â´",
-              "displayName": "Value Created (VI) â´"
+              "nativeQueryRef": "Value Created (VI) ⁴",
+              "displayName": "Value Created (VI) ⁴"
             },
             {
               "field": {
@@ -134,7 +134,7 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_vi_value_created_per_hr",
-              "displayName": "Value Created / Hr (VI) â´"
+              "displayName": "Value Created / Hr (VI) ⁴"
             },
             {
               "field": {
@@ -148,7 +148,7 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_vi_value_created_per_rep",
-              "displayName": "Value / Rep (VI) â´"
+              "displayName": "Value / Rep (VI) ⁴"
             }
           ]
         }
@@ -568,7 +568,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -605,7 +605,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -639,10 +639,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -676,10 +676,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -713,10 +713,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -750,10 +750,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -787,10 +787,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1245,7 +1245,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/8fc2aa321357b952781e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/8fc2aa321357b952781e/visual.json
@@ -513,10 +513,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -550,10 +550,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -587,10 +587,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -624,10 +624,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/a31d52a77844e79fd980/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/a31d52a77844e79fd980/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year1",
               "active": true
             }
@@ -62,7 +62,7 @@
                 }
               },
               "queryRef": "Sum(ssr_history.step_success_prob)",
-              "displayName": "Predicted Success (DI) Â²"
+              "displayName": "Predicted Success (DI) ²"
             },
             {
               "field": {
@@ -119,8 +119,8 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_vi_value_created",
-              "nativeQueryRef": "Value Created (VI) â´",
-              "displayName": "Value Created (VI) â´"
+              "nativeQueryRef": "Value Created (VI) ⁴",
+              "displayName": "Value Created (VI) ⁴"
             },
             {
               "field": {
@@ -134,7 +134,7 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_vi_value_created_per_hr",
-              "displayName": "Value Created / Hr (VI) â´"
+              "displayName": "Value Created / Hr (VI) ⁴"
             },
             {
               "field": {
@@ -148,7 +148,7 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_vi_value_created_per_rep",
-              "displayName": "Value / Rep (VI) â´"
+              "displayName": "Value / Rep (VI) ⁴"
             }
           ]
         }
@@ -568,7 +568,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -605,7 +605,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -639,10 +639,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -676,10 +676,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -713,10 +713,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -750,10 +750,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -787,10 +787,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -824,10 +824,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1282,7 +1282,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/afb0f076988d32c115bb/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/afb0f076988d32c115bb/visual.json
@@ -565,10 +565,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -602,10 +602,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -639,10 +639,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/c392712352aa4b1354d7/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/c392712352aa4b1354d7/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year1",
               "active": true
             }
@@ -62,7 +62,7 @@
                 }
               },
               "queryRef": "Sum(ssr_history.step_success_prob)",
-              "displayName": "Predicted Success (DI) Â²"
+              "displayName": "Predicted Success (DI) ²"
             },
             {
               "field": {
@@ -76,8 +76,8 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_duration_hrs_post_sales_sales_process_step",
-              "nativeQueryRef": "Tot. Time Spent Post-Sales Â³",
-              "displayName": "Tot. Time Spent Post-Sales Â³"
+              "nativeQueryRef": "Tot. Time Spent Post-Sales ³",
+              "displayName": "Tot. Time Spent Post-Sales ³"
             },
             {
               "field": {
@@ -91,7 +91,7 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_duration_hrs_per_step",
-              "displayName": "Time Spent per Attempt (CI) Â³"
+              "displayName": "Time Spent per Attempt (CI) ³"
             },
             {
               "field": {
@@ -105,7 +105,7 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_duration_hrs_rep_week",
-              "displayName": "Avg. Time Spent per Rep / Week Â³"
+              "displayName": "Avg. Time Spent per Rep / Week ³"
             },
             {
               "field": {
@@ -119,8 +119,8 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_vi_value_created",
-              "nativeQueryRef": "Value Created (VI) â´",
-              "displayName": "Value Created (VI) â´"
+              "nativeQueryRef": "Value Created (VI) ⁴",
+              "displayName": "Value Created (VI) ⁴"
             },
             {
               "field": {
@@ -134,7 +134,7 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_vi_value_created_per_hr",
-              "displayName": "Value Created / Hr (VI) â´"
+              "displayName": "Value Created / Hr (VI) ⁴"
             },
             {
               "field": {
@@ -148,7 +148,7 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_vi_value_created_per_rep",
-              "displayName": "Value / Rep (VI) â´"
+              "displayName": "Value / Rep (VI) ⁴"
             }
           ]
         }
@@ -568,7 +568,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -605,7 +605,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -639,10 +639,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -676,10 +676,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -713,10 +713,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -750,10 +750,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1208,7 +1208,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/c8e0c57deaf7aa5a47df/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/c8e0c57deaf7aa5a47df/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year1",
               "active": true
             },
@@ -53,7 +53,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -63,7 +63,7 @@
                   "Level": "Quarter"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Quarter",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Quarter",
               "nativeQueryRef": "Fiscal Date Quarter1",
               "active": true
             }
@@ -132,7 +132,7 @@
                             "Entity": "users_history"
                           }
                         },
-                        "Property": "col.user.user_role_function"
+                        "Property": "user.user_role"
                       }
                     },
                     "Right": {
@@ -462,7 +462,7 @@
             "text": {
               "expr": {
                 "Literal": {
-                  "Value": "'Win Rate (DI) Â²'"
+                  "Value": "'Win Rate (DI) ²'"
                 }
               }
             },
@@ -664,7 +664,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },
@@ -690,7 +690,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/cfb8e71434e5405db35e/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection8e195fc0bacff3bf81e8/visuals/cfb8e71434e5405db35e/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year1",
               "active": true
             },
@@ -53,7 +53,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -63,7 +63,7 @@
                   "Level": "Quarter"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Quarter",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Quarter",
               "nativeQueryRef": "Fiscal Date Quarter1",
               "active": true
             }
@@ -132,7 +132,7 @@
                             "Entity": "users_history"
                           }
                         },
-                        "Property": "col.user.user_role_function"
+                        "Property": "user.user_role"
                       }
                     },
                     "Right": {
@@ -462,7 +462,7 @@
             "text": {
               "expr": {
                 "Literal": {
-                  "Value": "'Conversion Rate (DI) Â²'"
+                  "Value": "'Conversion Rate (DI) ²'"
                 }
               }
             },
@@ -632,7 +632,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },
@@ -658,7 +658,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/652b289c3a4fdf11f0a3/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/652b289c3a4fdf11f0a3/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Date Year1",
               "active": true
             },
@@ -53,7 +53,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Date"
                         }
                       },
@@ -63,7 +63,7 @@
                   "Level": "Day"
                 }
               },
-              "queryRef": "cal_end_dates.Date.VariaciÃ³n.Date Hierarchy.Day",
+              "queryRef": "cal_end_dates.Date.Variación.Date Hierarchy.Day",
               "nativeQueryRef": "Date Day",
               "active": false
             }
@@ -180,7 +180,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Name": "VariaciÃ³n",
+                        "Name": "Variación",
                         "Property": "Date"
                       }
                     },
@@ -661,7 +661,7 @@
                     "Entity": "users_history"
                   }
                 },
-                "Property": "ci_time_alloc_existing_customer_selling"
+                "Property": "ci_time_alloc_upselling"
               }
             },
             "Function": 1
@@ -793,7 +793,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Date"
                   }
                 },
@@ -819,7 +819,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/a024f4430950a8ce6993/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/a024f4430950a8ce6993/visual.json
@@ -167,10 +167,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -198,10 +198,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -229,10 +229,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -260,10 +260,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -291,10 +291,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -322,10 +322,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -353,10 +353,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/b59d901f5b3a3c06cff2/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb411a324406434ef62d2/visuals/b59d901f5b3a3c06cff2/visual.json
@@ -1714,10 +1714,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "ssr_history"
+                    "Entity": "users_history"
                   }
                 },
-                "Property": "vi_value_repeat"
+                "Property": "vi_value_received_total"
               }
             },
             "Function": 0
@@ -1750,10 +1750,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "ssr_history"
+                    "Entity": "users_history"
                   }
                 },
-                "Property": "vi_value_created"
+                "Property": "vi_value_created_selling"
               }
             },
             "Function": 0

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/0d73b84e6936cbf3d3c2/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/0d73b84e6936cbf3d3c2/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year1",
               "active": true
             }
@@ -111,7 +111,7 @@
                             "Entity": "users_history"
                           }
                         },
-                        "Property": "col.user.user_role_function"
+                        "Property": "user.user_role"
                       }
                     },
                     "Right": {
@@ -208,7 +208,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -249,7 +249,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -290,7 +290,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -331,7 +331,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -372,7 +372,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -414,7 +414,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -640,7 +640,7 @@
             "text": {
               "expr": {
                 "Literal": {
-                  "Value": "'Predicted Win Rate by Creator Role Function - Prospecting only (DI) Â² Â³'"
+                  "Value": "'Predicted Win Rate by Creator Role Function - Prospecting only (DI) ² ³'"
                 }
               }
             },
@@ -753,7 +753,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/256b3983fb9cdbccb258/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/256b3983fb9cdbccb258/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year1",
               "active": true
             }
@@ -120,7 +120,7 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_success_prob_avg",
-              "displayName": "Avg. Pred. Success Rate Â²"
+              "displayName": "Avg. Pred. Success Rate ²"
             },
             {
               "field": {
@@ -715,7 +715,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -752,7 +752,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -786,10 +786,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -823,10 +823,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -860,10 +860,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -897,10 +897,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -934,10 +934,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -971,10 +971,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1008,10 +1008,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_2940a596-a5c7-4308-bbcb-a30484afa0c4"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1045,10 +1045,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_2940a596-a5c7-4308-bbcb-a30484afa0c4"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1082,10 +1082,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_2940a596-a5c7-4308-bbcb-a30484afa0c4"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1119,10 +1119,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1497,7 +1497,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/2e240843c6839d986d46/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/2e240843c6839d986d46/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year1",
               "active": true
             },
@@ -53,7 +53,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -63,7 +63,7 @@
                   "Level": "Day"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Day",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Day",
               "nativeQueryRef": "Fiscal Date Day",
               "active": false
             }
@@ -646,7 +646,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -683,7 +683,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -717,10 +717,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -754,10 +754,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -791,10 +791,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -828,10 +828,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -865,10 +865,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -902,10 +902,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -939,10 +939,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_2940a596-a5c7-4308-bbcb-a30484afa0c4"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -976,10 +976,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_2940a596-a5c7-4308-bbcb-a30484afa0c4"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1013,10 +1013,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_2940a596-a5c7-4308-bbcb-a30484afa0c4"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1050,10 +1050,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1087,10 +1087,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1303,7 +1303,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },
@@ -1328,7 +1328,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/33efe70b60b99f54dcbb/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/33efe70b60b99f54dcbb/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year1",
               "active": true
             }
@@ -105,7 +105,7 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_success_prob_avg",
-              "displayName": "Avg. Pred. Success Rate Â²"
+              "displayName": "Avg. Pred. Success Rate ²"
             },
             {
               "field": {
@@ -679,7 +679,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -716,7 +716,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year(s)"
                       }
                     },
                     "Right": {
@@ -750,10 +750,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -787,10 +787,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_639cfabb-5255-4dfb-9e63-db8dd997d813"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -824,10 +824,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -861,10 +861,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -909,10 +909,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -946,10 +946,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -983,10 +983,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_2940a596-a5c7-4308-bbcb-a30484afa0c4"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1020,10 +1020,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_2940a596-a5c7-4308-bbcb-a30484afa0c4"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1057,10 +1057,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_2940a596-a5c7-4308-bbcb-a30484afa0c4"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1094,10 +1094,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1131,10 +1131,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -1177,7 +1177,7 @@
             "text": {
               "expr": {
                 "Literal": {
-                  "Value": "'Pipeline -  TrueAI  (New Logoâ´)'"
+                  "Value": "'Pipeline -  TrueAI  (New Logo⁴)'"
                 }
               }
             },
@@ -1275,7 +1275,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/5c7a8f65e07bd133d6dd/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/5c7a8f65e07bd133d6dd/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year1",
               "active": true
             },
@@ -53,7 +53,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -63,7 +63,7 @@
                   "Level": "Quarter"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Quarter",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Quarter",
               "nativeQueryRef": "Fiscal Date Quarter1",
               "active": true
             }
@@ -136,7 +136,7 @@
                             "Entity": "users_history"
                           }
                         },
-                        "Property": "col.user.user_role_function"
+                        "Property": "user.user_role"
                       }
                     },
                     "Right": {
@@ -892,7 +892,7 @@
             "text": {
               "expr": {
                 "Literal": {
-                  "Value": "'Predicted Win Rate by Creator Group (DI) Â² Â³'"
+                  "Value": "'Predicted Win Rate by Creator Group (DI) ² ³'"
                 }
               }
             },
@@ -1027,7 +1027,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },
@@ -1053,7 +1053,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/68d77b508914341348c4/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/68d77b508914341348c4/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year1",
               "active": true
             }
@@ -94,7 +94,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Name": "VariaciÃ³n",
+                        "Name": "Variación",
                         "Property": "Fiscal Date"
                       }
                     },
@@ -262,7 +262,7 @@
                             "Entity": "ssr_history"
                           }
                         },
-                        "Property": "opp_lost_stage"
+                        "Property": "col.lost_stage"
                       }
                     },
                     "Right": {
@@ -303,7 +303,7 @@
                             "Entity": "ssr_history"
                           }
                         },
-                        "Property": "opp_lost_stage"
+                        "Property": "col.lost_stage"
                       }
                     },
                     "Right": {
@@ -344,7 +344,7 @@
                             "Entity": "ssr_history"
                           }
                         },
-                        "Property": "opp_lost_stage"
+                        "Property": "col.lost_stage"
                       }
                     },
                     "Right": {
@@ -564,7 +564,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/768bd4f9d2fe5c55352d/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/768bd4f9d2fe5c55352d/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year1",
               "active": true
             },
@@ -53,7 +53,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -63,7 +63,7 @@
                   "Level": "Quarter"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Quarter",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Quarter",
               "nativeQueryRef": "Fiscal Date Quarter1",
               "active": true
             }
@@ -152,7 +152,7 @@
                             "Entity": "users_history"
                           }
                         },
-                        "Property": "col.user.user_role_function"
+                        "Property": "user.user_role"
                       }
                     },
                     "Right": {
@@ -534,7 +534,7 @@
             "text": {
               "expr": {
                 "Literal": {
-                  "Value": "' Predicted Win Rate by Sales Process Step (DI) Â²'"
+                  "Value": "' Predicted Win Rate by Sales Process Step (DI) ²'"
                 }
               }
             },
@@ -732,7 +732,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },
@@ -757,7 +757,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/82155cfd75a3056d07bb/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/82155cfd75a3056d07bb/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Fiscal Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Fiscal Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Fiscal Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Fiscal Date Year1",
               "active": true
             }
@@ -226,7 +226,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -267,7 +267,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -308,7 +308,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -349,7 +349,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -390,7 +390,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -432,7 +432,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -718,7 +718,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -748,7 +748,7 @@
             "text": {
               "expr": {
                 "Literal": {
-                  "Value": "'Pipeline Creation by Role Function Â¹'"
+                  "Value": "'Pipeline Creation by Role Function ¹'"
                 }
               }
             },
@@ -829,7 +829,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Fiscal Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/c72b026fccd0dfd30790/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionb821801c632ff50fa5f5/visuals/c72b026fccd0dfd30790/visual.json
@@ -705,10 +705,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -742,10 +742,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_557797f7-17d9-4f5d-bc08-ab429d81d284"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/075a19161c3580f45de7/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/075a19161c3580f45de7/visual.json
@@ -235,7 +235,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_new_hires"
+            "metadata": "data_logs.meas.data_logs_user_new_hires"
           }
         },
         {
@@ -376,7 +376,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_new_hires"
+            "metadata": "data_logs.meas.data_logs_user_new_hires"
           }
         },
         {
@@ -464,7 +464,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_count_bop"
+            "metadata": "data_logs.meas.data_logs_user_count_bop"
           }
         },
         {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/4e36b15233f0e3fa1abc/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/4e36b15233f0e3fa1abc/visual.json
@@ -126,7 +126,7 @@
                     "Entity": "users"
                   }
                 },
-                "Property": "trueai_user_role_function"
+                "Property": "col.user_role_function"
               }
             },
             "direction": "Ascending"
@@ -163,7 +163,7 @@
                             "Entity": "users_history"
                           }
                         },
-                        "Property": "col.user.user_role_function"
+                        "Property": "user.user_role"
                       }
                     },
                     "Right": {
@@ -248,7 +248,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_count_eop"
+            "metadata": "data_logs.meas.data_logs_user_count_eop"
           }
         },
         {
@@ -297,7 +297,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -338,7 +338,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -380,7 +380,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -421,7 +421,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -462,7 +462,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -504,7 +504,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -546,7 +546,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -817,7 +817,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/7f17bf2c81f9b581fc30/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/7f17bf2c81f9b581fc30/visual.json
@@ -235,7 +235,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_new_hires"
+            "metadata": "data_logs.meas.data_logs_user_new_hires"
           }
         },
         {
@@ -376,7 +376,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_new_hires"
+            "metadata": "data_logs.meas.data_logs_user_new_hires"
           }
         },
         {
@@ -464,7 +464,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_count_bop"
+            "metadata": "data_logs.meas.data_logs_user_count_bop"
           }
         },
         {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/8400e62bf00655656abb/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/8400e62bf00655656abb/visual.json
@@ -118,7 +118,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_new_hires"
+            "metadata": "data_logs.meas.data_logs_user_new_hires"
           }
         },
         {
@@ -136,7 +136,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_new_terminations"
+            "metadata": "data_logs.meas.data_logs_user_new_terminations"
           }
         }
       ],

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/b99c1abf7708c0e28eba/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/b99c1abf7708c0e28eba/visual.json
@@ -238,7 +238,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_new_hires"
+            "metadata": "data_logs.meas.data_logs_user_new_hires"
           }
         },
         {
@@ -379,7 +379,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_new_hires"
+            "metadata": "data_logs.meas.data_logs_user_new_hires"
           }
         },
         {
@@ -467,7 +467,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_count_bop"
+            "metadata": "data_logs.meas.data_logs_user_count_bop"
           }
         },
         {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/c4451eae6265c046b9aa/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/c4451eae6265c046b9aa/visual.json
@@ -235,7 +235,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_new_hires"
+            "metadata": "data_logs.meas.data_logs_user_new_hires"
           }
         },
         {
@@ -376,7 +376,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_new_hires"
+            "metadata": "data_logs.meas.data_logs_user_new_hires"
           }
         },
         {
@@ -464,7 +464,7 @@
             }
           },
           "selector": {
-            "metadata": "users_history.meas.data_logs_user_count_bop"
+            "metadata": "data_logs.meas.data_logs_user_count_bop"
           }
         },
         {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/d9903380f436267abdfc/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiond61e59bd3602ba4a6207/visuals/d9903380f436267abdfc/visual.json
@@ -204,7 +204,7 @@
                             "Entity": "users_history"
                           }
                         },
-                        "Property": "col.user.user_role_function"
+                        "Property": "user.user_role"
                       }
                     },
                     "Right": {
@@ -320,7 +320,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -361,7 +361,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -403,7 +403,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -444,7 +444,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {
@@ -485,7 +485,7 @@
                             "Entity": "users"
                           }
                         },
-                        "Property": "trueai_user_role_function"
+                        "Property": "col.user_role_function"
                       }
                     },
                     "Right": {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/1bfcdd7eec09387cddc7/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/1bfcdd7eec09387cddc7/visual.json
@@ -167,10 +167,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -198,10 +198,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -229,10 +229,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -260,10 +260,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -291,10 +291,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -322,10 +322,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {
@@ -353,10 +353,10 @@
                                 "Measure": {
                                   "Expression": {
                                     "SourceRef": {
-                                      "Entity": "metadata_ai_scores"
+                                      "Entity": "ai_scores"
                                     }
                                   },
-                                  "Property": "meas.ai_scores_text"
+                                  "Property": "meas.ai_scores_ci_time_alloc_text"
                                 }
                               },
                               "Right": {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/22e4971668b71abebbf7/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/22e4971668b71abebbf7/visual.json
@@ -1701,10 +1701,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "ssr_history"
+                    "Entity": "users_history"
                   }
                 },
-                "Property": "vi_value_repeat"
+                "Property": "vi_value_received_total"
               }
             },
             "Function": 0
@@ -1737,10 +1737,10 @@
               "Column": {
                 "Expression": {
                   "SourceRef": {
-                    "Entity": "ssr_history"
+                    "Entity": "users_history"
                   }
                 },
-                "Property": "vi_value_created"
+                "Property": "vi_value_created_selling"
               }
             },
             "Function": 0

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/f1e07f9b24f32b91e610/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondba0f7d79d63b13c9bdc/visuals/f1e07f9b24f32b91e610/visual.json
@@ -27,7 +27,7 @@
                               "Entity": "cal_end_dates"
                             }
                           },
-                          "Name": "VariaciÃ³n",
+                          "Name": "Variación",
                           "Property": "Date"
                         }
                       },
@@ -37,7 +37,7 @@
                   "Level": "Year"
                 }
               },
-              "queryRef": "cal_end_dates.Date.VariaciÃ³n.Date Hierarchy.Year",
+              "queryRef": "cal_end_dates.Date.Variación.Date Hierarchy.Year",
               "nativeQueryRef": "Date Year1",
               "active": true
             }
@@ -154,7 +154,7 @@
                             "Entity": "cal_end_dates"
                           }
                         },
-                        "Name": "VariaciÃ³n",
+                        "Name": "Variación",
                         "Property": "Date"
                       }
                     },
@@ -635,7 +635,7 @@
                     "Entity": "users_history"
                   }
                 },
-                "Property": "ci_time_alloc_existing_customer_selling"
+                "Property": "ci_time_alloc_upselling"
               }
             },
             "Function": 1
@@ -767,7 +767,7 @@
                         "Entity": "cal_end_dates"
                       }
                     },
-                    "Name": "VariaciÃ³n",
+                    "Name": "Variación",
                     "Property": "Date"
                   }
                 },

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/8aae78a889acef1a2264/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectiondf5a7a5533d27e483bbb/visuals/8aae78a889acef1a2264/visual.json
@@ -355,10 +355,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_f142aaad-c029-4445-8110-9fdfbb1cd5b6"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -397,10 +397,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_f142aaad-c029-4445-8110-9fdfbb1cd5b6"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -439,10 +439,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_d9cd643e-7eb2-4078-b7d4-6261fea9cd66"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -481,10 +481,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_d9cd643e-7eb2-4078-b7d4-6261fea9cd66"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -523,10 +523,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_d9cd643e-7eb2-4078-b7d4-6261fea9cd66"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -565,10 +565,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_d9cd643e-7eb2-4078-b7d4-6261fea9cd66"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/5946262ab6b8df350d86/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSectionfe1f4168c3550aa4051e/visuals/5946262ab6b8df350d86/visual.json
@@ -361,10 +361,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_f142aaad-c029-4445-8110-9fdfbb1cd5b6"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -403,10 +403,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_f142aaad-c029-4445-8110-9fdfbb1cd5b6"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -445,10 +445,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_d9cd643e-7eb2-4078-b7d4-6261fea9cd66"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -487,10 +487,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_d9cd643e-7eb2-4078-b7d4-6261fea9cd66"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -528,10 +528,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_d9cd643e-7eb2-4078-b7d4-6261fea9cd66"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {
@@ -570,10 +570,10 @@
                       "Column": {
                         "Expression": {
                           "SourceRef": {
-                            "Entity": "cal_end_dates"
+                            "Entity": "LocalDateTable_d9cd643e-7eb2-4078-b7d4-6261fea9cd66"
                           }
                         },
-                        "Property": "year"
+                        "Property": "Year"
                       }
                     },
                     "Right": {

--- a/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/0d80927ec2602da36ecd/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/0d80927ec2602da36ecd/visual.json
@@ -227,7 +227,7 @@
             }
           },
           "selector": {
-            "metadata": "opp_line_items.meas.opps_delta_expected_pct"
+            "metadata": "opps.meas.opps_delta_expected_pct"
           }
         },
         {
@@ -257,7 +257,7 @@
                             "Entity": "opps"
                           }
                         },
-                        "Property": "trueai_discount_pct_tier"
+                        "Property": "col.discount_tier"
                       }
                     },
                     "Right": {
@@ -299,7 +299,7 @@
                             "Entity": "opps"
                           }
                         },
-                        "Property": "trueai_discount_pct_tier"
+                        "Property": "col.discount_tier"
                       }
                     },
                     "Right": {
@@ -341,7 +341,7 @@
                             "Entity": "opps"
                           }
                         },
-                        "Property": "trueai_discount_pct_tier"
+                        "Property": "col.discount_tier"
                       }
                     },
                     "Right": {
@@ -383,7 +383,7 @@
                             "Entity": "opps"
                           }
                         },
-                        "Property": "trueai_discount_pct_tier"
+                        "Property": "col.discount_tier"
                       }
                     },
                     "Right": {
@@ -425,7 +425,7 @@
                             "Entity": "opps"
                           }
                         },
-                        "Property": "trueai_discount_pct_tier"
+                        "Property": "col.discount_tier"
                       }
                     },
                     "Right": {
@@ -466,7 +466,7 @@
                             "Entity": "opps"
                           }
                         },
-                        "Property": "trueai_discount_pct_tier"
+                        "Property": "col.discount_tier"
                       }
                     },
                     "Right": {
@@ -508,7 +508,7 @@
                             "Entity": "opps"
                           }
                         },
-                        "Property": "trueai_discount_pct_tier"
+                        "Property": "col.discount_tier"
                       }
                     },
                     "Right": {

--- a/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/3a762df3c15e7ec23e81/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/a870a1bb0b6919938d14/visuals/3a762df3c15e7ec23e81/visual.json
@@ -27,8 +27,8 @@
                 }
               },
               "queryRef": "DimDiscountTier.trueai_discount_pct_tier",
-              "nativeQueryRef": "Discount Tier Â¹",
-              "displayName": "Discount Tier Â¹"
+              "nativeQueryRef": "Discount Tier ¹",
+              "displayName": "Discount Tier ¹"
             },
             {
               "field": {
@@ -72,8 +72,8 @@
                 }
               },
               "queryRef": "ssr_history.meas.ssr_history_step_count",
-              "nativeQueryRef": "# Deals â¹",
-              "displayName": "# Deals â¹"
+              "nativeQueryRef": "# Deals ⁹",
+              "displayName": "# Deals ⁹"
             },
             {
               "field": {
@@ -132,8 +132,8 @@
                 }
               },
               "queryRef": "opps.meas.opps_delta_expected_pct",
-              "nativeQueryRef": "Success Rate Performance Lift (Actual vs Expected) Â²",
-              "displayName": "Success Rate Performance Lift (Actual vs Expected) Â²"
+              "nativeQueryRef": "Success Rate Performance Lift (Actual vs Expected) ²",
+              "displayName": "Success Rate Performance Lift (Actual vs Expected) ²"
             },
             {
               "field": {
@@ -147,8 +147,8 @@
                 }
               },
               "queryRef": "opps.meas.opps_excess_over_discount_amount_by_tier",
-              "nativeQueryRef": "Potentially Over Discounted Amt. Â³",
-              "displayName": "Potentially Over Discounted Amt. Â³",
+              "nativeQueryRef": "Potentially Over Discounted Amt. ³",
+              "displayName": "Potentially Over Discounted Amt. ³",
               "format": "\\$#,0;(\\$#,0);\\$#,0"
             }
           ]
@@ -257,7 +257,7 @@
             }
           },
           "selector": {
-            "metadata": "opp_line_items.meas.opps_delta_expected_pct"
+            "metadata": "opps.meas.opps_delta_expected_pct"
           }
         },
         {
@@ -543,7 +543,7 @@
                 }
               }
             ],
-            "metadata": "opp_line_items.meas.opps_delta_expected_pct"
+            "metadata": "opps.meas.opps_delta_expected_pct"
           }
         },
         {
@@ -1110,7 +1110,7 @@
                 "Entity": "opps"
               }
             },
-            "Property": "meas.opps_over_discounted_total"
+            "Property": "meas.opps_over_discounted_amt"
           }
         },
         "type": "Advanced",

--- a/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/b74e3013e575776750e3/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/b2298fbfb64c37e2a75a/visuals/b74e3013e575776750e3/visual.json
@@ -10,22 +10,100 @@
     "tabOrder": 71000
   },
   "visual": {
-    "visualType": "shape",
+    "visualType": "slicer",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "booking_amount_display_mode"
+                    }
+                  },
+                  "Property": "amount_display_mode"
+                }
+              },
+              "queryRef": "booking_amount_display_mode.amount_display_mode",
+              "nativeQueryRef": "amount_display_mode",
+              "active": true
+            }
+          ]
+        }
+      }
+    },
     "objects": {
-      "shape": [
+      "data": [
         {
           "properties": {
-            "tileShape": {
+            "mode": {
               "expr": {
                 "Literal": {
-                  "Value": "'rectangle'"
+                  "Value": "'Dropdown'"
+                }
+              }
+            },
+            "endDate": {
+              "expr": {
+                "Literal": {
+                  "Value": "datetime'2021-12-31T00:00:00'"
                 }
               }
             }
           }
         }
       ],
-      "fill": [
+      "slider": [
+        {
+          "properties": {
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#213E54'"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "date": [
+        {
+          "properties": {
+            "textSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "12D"
+                }
+              }
+            },
+            "fontColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#213E54'"
+                    }
+                  }
+                }
+              }
+            },
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'''Segoe UI'', wf_segoe-ui_normal, helvetica, arial, sans-serif'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "header": [
         {
           "properties": {
             "show": {
@@ -38,20 +116,344 @@
           }
         }
       ],
-      "outline": [
+      "selection": [
         {
           "properties": {
-            "show": {
+            "selectAllCheckboxEnabled": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "singleSelect": {
               "expr": {
                 "Literal": {
                   "Value": "false"
+                }
+              }
+            },
+            "strictSingleSelect": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "general": [
+        {
+          "properties": {
+            "outlineColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": -0.3
+                    }
+                  }
+                }
+              }
+            },
+            "filter": {
+              "filter": {
+                "Version": 2,
+                "From": [
+                  {
+                    "Name": "b",
+                    "Entity": "booking_amount_display_mode",
+                    "Type": 0
+                  }
+                ],
+                "Where": [
+                  {
+                    "Condition": {
+                      "In": {
+                        "Expressions": [
+                          {
+                            "Column": {
+                              "Expression": {
+                                "SourceRef": {
+                                  "Source": "b"
+                                }
+                              },
+                              "Property": "amount_display_mode"
+                            }
+                          }
+                        ],
+                        "Values": [
+                          [
+                            {
+                              "Literal": {
+                                "Value": "'Annual Bookings'"
+                              }
+                            }
+                          ]
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "items": [
+        {
+          "properties": {
+            "fontColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": -0.1
+                    }
+                  }
+                }
+              }
+            },
+            "background": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#2D2E3B'"
+                    }
+                  }
+                }
+              }
+            },
+            "outlineStyle": {
+              "expr": {
+                "Literal": {
+                  "Value": "0D"
+                }
+              }
+            },
+            "textSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "11D"
+                }
+              }
+            },
+            "padding": {
+              "expr": {
+                "Literal": {
+                  "Value": "3D"
                 }
               }
             }
           }
         }
       ]
-    }
+    },
+    "visualContainerObjects": {
+      "background": [
+        {
+          "properties": {
+            "transparency": {
+              "expr": {
+                "Literal": {
+                  "Value": "4D"
+                }
+              }
+            },
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "border": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": -0.3
+                    }
+                  }
+                }
+              }
+            },
+            "radius": {
+              "expr": {
+                "Literal": {
+                  "Value": "0D"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "title": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "text": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Booking Amount Display Mode'"
+                }
+              }
+            },
+            "fontColor": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "ThemeDataColor": {
+                      "ColorId": 0,
+                      "Percent": 0
+                    }
+                  }
+                }
+              }
+            },
+            "background": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#2D2E3B'"
+                    }
+                  }
+                }
+              }
+            },
+            "fontFamily": {
+              "expr": {
+                "Literal": {
+                  "Value": "'''Segoe UI Semibold'', wf_segoe-ui_semibold, helvetica, arial, sans-serif'"
+                }
+              }
+            },
+            "alignment": {
+              "expr": {
+                "Literal": {
+                  "Value": "'left'"
+                }
+              }
+            },
+            "fontSize": {
+              "expr": {
+                "Literal": {
+                  "Value": "10D"
+                }
+              }
+            },
+            "heading": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Heading4'"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "divider": [
+        {
+          "properties": {
+            "show": {
+              "expr": {
+                "Literal": {
+                  "Value": "true"
+                }
+              }
+            },
+            "color": {
+              "solid": {
+                "color": {
+                  "expr": {
+                    "Literal": {
+                      "Value": "'#689137'"
+                    }
+                  }
+                }
+              }
+            },
+            "width": {
+              "expr": {
+                "Literal": {
+                  "Value": "8D"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "spacing": [
+        {
+          "properties": {
+            "verticalSpacing": {
+              "expr": {
+                "Literal": {
+                  "Value": "3D"
+                }
+              }
+            },
+            "customizeSpacing": {
+              "expr": {
+                "Literal": {
+                  "Value": "false"
+                }
+              }
+            },
+            "spaceBelowTitleArea": {
+              "expr": {
+                "Literal": {
+                  "Value": "4D"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "syncGroup": {
+      "groupName": "amount_display_mode",
+      "fieldChanges": true,
+      "filterChanges": true
+    },
+    "drillFilterOtherVisuals": true
   },
   "filterConfig": {
     "filters": [


### PR DESCRIPTION
## Summary

Reverts PR #687 from staging.

## Why

The changes from PR #687 should not remain in staging. This PR is a normal revert of merge commit `e87ee80a991d9025af5eeff35b3ae8c25ddcba00` so staging history is preserved while removing those report/PBIX changes.

## Reverted commit

- `e87ee80a9` - Merge pull request #687 from `fix-strategy-report-missing-references-20260708`

## Validation

- Revert commit created successfully with `git revert -m 1 e87ee80a991d9025af5eeff35b3ae8c25ddcba00`.
- Direct push to staging was rejected because `staging` is protected, so this PR is the required path.