### PR TITLE
Align ADE propensity measure names

### DIFF
--- a/powerbi/Dataset - Azure Data Lake - Automatic Data Enhancement.pbix
+++ b/powerbi/Dataset - Azure Data Lake - Automatic Data Enhancement.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5b302f7d219cfc5a530353bf7092518dd034f1fb32ceed5b3c4764fcbcd4cc71
-size 108959112
+oid sha256:a69033a8850df8bdab5e00f7ad1938320e220eddb8d62881e34b48f4abb299fb
+size 108790866

--- a/powerbi/src/Dataset - Azure Data Lake - Automatic Data Enhancement.SemanticModel/definition/tables/metadata_ai_scores.tmdl
+++ b/powerbi/src/Dataset - Azure Data Lake - Automatic Data Enhancement.SemanticModel/definition/tables/metadata_ai_scores.tmdl
@@ -1751,8 +1751,8 @@ table metadata_ai_scores
 	/// AI_EXCLUDE: Helper, redundant, or field-pass-through measure used for internal reuse only.
 	measure 'meas.ai_scores_new_logo_existing_customer_selling' =
 			
-			var _new_logo = [meas.ai_scores_pred_new_logo_selling]      // new logo sellign score
-			var _existing = [meas.ai_scores_pred_existing_customer_selling]         // existing customer selling score
+			var _new_logo = [meas.ai_scores_propensity_new_logo_selling]      // new logo sellign score
+			var _existing = [meas.ai_scores_propensity_existing_customer_selling]         // existing customer selling score
 			var res = (_new_logo+_existing)/2
 			
 			RETURN
@@ -1933,7 +1933,7 @@ table metadata_ai_scores
 		lineageTag: d286bf08-11f1-4d97-b1e2-36dbf861d4a3
 
 	/// AI_EXCLUDE: Helper, redundant, or field-pass-through measure used for internal reuse only.
-	measure 'meas.ai_scores_pred_existing_customer_selling' = ```
+	measure 'meas.ai_scores_propensity_existing_customer_selling' = ```
 			
 						var latest_row  = CALCULATETABLE(TOPN(1,companies_history, companies_history[_sys_processed_as_of], DESC))  // get the latest row
 						var factor1 = COALESCE(MAXX(latest_row, companies_history[di_pred_existing_customer_selling_auc]), 0)     // get the latest auc for existing customer
@@ -1953,10 +1953,10 @@ table metadata_ai_scores
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
 	/// AI_EXCLUDE: Helper, redundant, or field-pass-through measure used for internal reuse only.
-	measure 'meas.ai_scores_pred_existing_customer_selling_text' = ```
+	measure 'meas.ai_scores_propensity_existing_customer_selling_text' = ```
 			
 			
-			var _conf = [meas.ai_scores_pred_existing_customer_selling] // get the existing customer selling score
+			var _conf = [meas.ai_scores_propensity_existing_customer_selling] // get the existing customer selling score
 			
 			var _status_ = IF(
 			    _conf > 94, "Excellent", 
@@ -1976,7 +1976,7 @@ table metadata_ai_scores
 		lineageTag: 8e71ca17-df28-4dc2-afa6-91f77e929f65
 
 	/// AI_EXCLUDE: Helper, redundant, or field-pass-through measure used for internal reuse only.
-	measure 'meas.ai_scores_pred_new_logo_selling' = ```
+	measure 'meas.ai_scores_propensity_new_logo_selling' = ```
 			
 			var factor1 = COALESCE([meas.ai_scores_new_logo_selling_factor1_value], 0)
 			var factor2 = COALESCE([meas.ai_scores_new_logo_selling_factor2_value], 0)
@@ -1994,9 +1994,9 @@ table metadata_ai_scores
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
 	/// AI_EXCLUDE: Helper, redundant, or field-pass-through measure used for internal reuse only.
-	measure 'meas.ai_scores_pred_new_logo_selling_text' = ```
+	measure 'meas.ai_scores_propensity_new_logo_selling_text' = ```
 			
-			var _conf = [meas.ai_scores_pred_new_logo_selling] // get the new logo selling score
+			var _conf = [meas.ai_scores_propensity_new_logo_selling] // get the new logo selling score
 			
 			var _status_ = IF(
 			    _conf > 94, "Excellent", 
@@ -2016,7 +2016,7 @@ table metadata_ai_scores
 		lineageTag: 5b99ef74-063c-4fd0-9ed0-c8e12406b3e6
 
 	/// AI_EXCLUDE: Helper, redundant, or field-pass-through measure used for internal reuse only.
-	measure 'meas.ai_scores_pred_post_sales_support' = ```
+	measure 'meas.ai_scores_propensity_post_sales_support' = ```
 			
 			var factor1 = COALESCE([meas.ai_scores_post_sales_support_factor1_value], 0)
 			var factor2 =  COALESCE([meas.ai_scores_post_sales_support_factor2_value], 0)
@@ -2034,9 +2034,9 @@ table metadata_ai_scores
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
 	/// AI_EXCLUDE: Helper, redundant, or field-pass-through measure used for internal reuse only.
-	measure 'meas.ai_scores_pred_post_sales_support_text' = ```
+	measure 'meas.ai_scores_propensity_post_sales_support_text' = ```
 			
-			var _conf = [meas.ai_scores_pred_post_sales_support]        // get the score 
+			var _conf = [meas.ai_scores_propensity_post_sales_support]        // get the score
 			
 			var _status_ = IF(
 			    _conf > 94, "Excellent", 
@@ -2056,7 +2056,7 @@ table metadata_ai_scores
 		lineageTag: 81fbf8fd-6984-44da-a73a-1b8088c84d53
 
 	/// AI_EXCLUDE: Helper, redundant, or field-pass-through measure used for internal reuse only.
-	measure 'meas.ai_scores_pred_prospecting' = ```
+	measure 'meas.ai_scores_propensity_prospecting' = ```
 			
 			var factor1 = COALESCE([meas.ai_scores_prospecting_factor1_value], 0)
 			var factor2 =  COALESCE([meas.ai_scores_prospecting_factor2_value], 0)
@@ -2073,9 +2073,9 @@ table metadata_ai_scores
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
 	/// AI_EXCLUDE: Helper, redundant, or field-pass-through measure used for internal reuse only.
-	measure 'meas.ai_scores_pred_prospecting_text' = ```
+	measure 'meas.ai_scores_propensity_prospecting_text' = ```
 			
-			var _conf = [meas.ai_scores_pred_prospecting] // get the prospecting pred score
+			var _conf = [meas.ai_scores_propensity_prospecting] // get the prospecting propensity score
 			
 			var _status_ = IF(
 			    _conf > 94, "Excellent", 
@@ -2502,10 +2502,10 @@ table metadata_ai_scores
 			
 			var res = SWITCH(
 			    score_name,
-			    "Prospecting Propensity", "meas.ai_scores_pred_prospecting",   
-			    "New Logo Selling Propensity", "meas.ai_scores_pred_new_logo_selling",    // score_id 2
-			    "Post-Sales Support Propensity", "meas.ai_scores_pred_post_sales_support",    // score_id 3
-			    "Existing Customer Selling Propensity", "meas.ai_scores_pred_existing_customer_selling",    // score_id 4
+			    "Prospecting Propensity", "meas.ai_scores_propensity_prospecting",
+			    "New Logo Selling Propensity", "meas.ai_scores_propensity_new_logo_selling",    // score_id 2
+			    "Post-Sales Support Propensity", "meas.ai_scores_propensity_post_sales_support",    // score_id 3
+			    "Existing Customer Selling Propensity", "meas.ai_scores_propensity_existing_customer_selling",    // score_id 4
 			    "Success Factor Analysis", "meas.ai_scores_factor_analysis",                      // score id 5
 			    "Potential ACV", "meas.ai_scores_potential_acv",                      // score id 6
 			    "List Price", "meas.ai_scores_all_list_price",                      // score id 7
@@ -3012,7 +3012,7 @@ table metadata_ai_scores
 			VAR raw_val =
 			    SWITCH(
 			        score_name,
-			        "Prospecting Propensity", [meas.ai_scores_pred_prospecting],
+			        "Prospecting Propensity", [meas.ai_scores_propensity_prospecting],
 			
 			        "New Logo Selling Propensity",
 			            (
@@ -3020,8 +3020,8 @@ table metadata_ai_scores
 			                + COALESCE([meas.ai_scores_new_logo_selling_factor1_value], 0)
 			            ) / 2,
 			
-			        "Post-Sales Support Propensity", [meas.ai_scores_pred_post_sales_support],
-			        "Existing Customer Selling Propensity", [meas.ai_scores_pred_existing_customer_selling],
+			        "Post-Sales Support Propensity", [meas.ai_scores_propensity_post_sales_support],
+			        "Existing Customer Selling Propensity", [meas.ai_scores_propensity_existing_customer_selling],
 			        "Success Factor Analysis", [meas.ai_scores_success_factor_analysis],
 			        "Potential ACV", [meas.ai_scores_potential_acv],
 			        "List Price", [meas.ai_scores_list_price],


### PR DESCRIPTION
## What changed

- Renames the four ADE AI Score measures from `meas.ai_scores_pred_*` to `meas.ai_scores_propensity_*`.
- Renames the corresponding `_text` measures.
- Updates all internal dependencies and `meas.ai_score_measure_name` routing strings to match the metadata sheet.
- Includes the Power BI report-version metadata generated with the model save.

## Why

The metadata sheet identifies the four measures using `meas.ai_scores_propensity_*`, while ADE still defined and returned the legacy `pred_*` identifiers.

## Validation

- Zero remaining legacy `meas.ai_scores_pred_*` references for the four scores.
- Four primary Propensity measure declarations exist exactly once.
- Four corresponding `_text` declarations exist exactly once.
- Git diff formatting check passed.