### PR TITLE
Update ADE propensity score calculation

### DIFF
--- a/powerbi/Automatic Data Enhancement Report.pbix
+++ b/powerbi/Automatic Data Enhancement Report.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fa3bffbb26f1fac0b8e45677c25521929e1814ad5708d9f4b62c17bbf19e3ee8
-size 1554779
+oid sha256:4d3450c85fc9cf686b74d4fd113dd4ca107561f29fd153141924999a33f35d0f
+size 1555082

--- a/powerbi/Dataset - Azure Data Lake - Automatic Data Enhancement.pbix
+++ b/powerbi/Dataset - Azure Data Lake - Automatic Data Enhancement.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a69033a8850df8bdab5e00f7ad1938320e220eddb8d62881e34b48f4abb299fb
-size 108790866
+oid sha256:6de360337bb39bfc7925fe85be57e6c2b9e87d6f8bdf1699192387c725ea3ce0
+size 104367029


### PR DESCRIPTION
## What changed

- Updated the Automatic Data Enhancement report PBIX.
- Updated the Automatic Data Enhancement dataset PBIX.
- Preserved the ADE Propensity score changes saved in the Power BI artifacts.

## Why

Publishes the latest ADE Propensity score calculation changes so they can be reviewed and promoted through `staging`.

## Impact

The ADE report and its dataset artifact remain synchronized for the Propensity score update.

## Validation

- `git diff --cached --check`
- `git lfs fsck`
- Confirmed only the two intended ADE PBIX files were committed; `.cleanwork/` was excluded.