### PR TITLE
Update Power BI report artifacts

### DIFF
--- a/powerbi/Automatic Data Enhancement Report.pbix
+++ b/powerbi/Automatic Data Enhancement Report.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4d3450c85fc9cf686b74d4fd113dd4ca107561f29fd153141924999a33f35d0f
-size 1555082
+oid sha256:ccf7c859cc0c77d4c0e9de184ecb1dffa7165ca7ad29efb9edb193bc1eb76c34
+size 1554779

--- a/powerbi/Management Report.pbix
+++ b/powerbi/Management Report.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6546912c91bbe7892bb8176e920efdd7f8d8e0afe4a0bee3f557bbdbb32d4733
+oid sha256:3bb759b7fc1dd66d424137a8d5de6089534fe03ea3de0e8fa30bda1f2470f875
 size 9896344

--- a/powerbi/Strategy Report.pbix
+++ b/powerbi/Strategy Report.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f2c0228892788b82d3ab0fcda76d6898be06d45967290ead340623e834ecd41e
-size 7512256
+oid sha256:f6172d4c46674a9fb97fdffa5e71cec29a18beb9bd7b2cf92e32e1c23694e313
+size 7511879

--- a/powerbi/Tactical Report.pbix
+++ b/powerbi/Tactical Report.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ff29abbefa1a538068fdf0b80b44b8f38ffe94e91981386f53319b862954a9b9
+oid sha256:8ff319c0d9e0d11a58e432bda28ae0f210dc96fd517d48c396cde7d5b500ae53
 size 7679530

--- a/powerbi/Utility Box Report.pbix
+++ b/powerbi/Utility Box Report.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b1810c1d57e2df53a2d4ac1a243047a631a13cba2de93f0cae3290d07bcde91
-size 7747625
+oid sha256:87d4c90ebbc512a0d8edc8dbfd6c18f37958f679d053213bb801271cdb63e234
+size 7747626


### PR DESCRIPTION
## What changed

Updated five Power BI report artifacts:

- Automatic Data Enhancement Report
- Management Report
- Strategy Report
- Tactical Report
- Utility Box Report

## Why

Publishes the latest saved Power BI report changes into the shared `staging` branch.

## Impact

The updated PBIX artifacts will be available from `staging` for deployment and review.

## Validation

- `git diff --cached --check` passed.
- `git lfs fsck` passed.
- All five PBIX files remain Git LFS tracked.
- `check_powerbi_platform_columns.py` and `check_ade_display_scores.py` could not run because neither `python` nor the Windows `py` launcher is installed in this environment.
- Diagram scroll-position-only JSON changes and `.cleanwork/` were excluded.