### PR TITLE
Add pricing and org capacity analytics

### DIFF
--- a/powerbi/Automatic Data Enhancement Report.pbix
+++ b/powerbi/Automatic Data Enhancement Report.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ccf7c859cc0c77d4c0e9de184ecb1dffa7165ca7ad29efb9edb193bc1eb76c34
-size 1554779
+oid sha256:76b247f95cdabfe064d0834fc3ddc3922887aeb83997b7fbb0ae85ae2631a228
+size 1555071

--- a/powerbi/Dataset - Azure Data Lake - Automatic Data Enhancement.pbix
+++ b/powerbi/Dataset - Azure Data Lake - Automatic Data Enhancement.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6de360337bb39bfc7925fe85be57e6c2b9e87d6f8bdf1699192387c725ea3ce0
-size 104367029
+oid sha256:2e127175b5ed367b5a18782a861b803b356c2e87eadb6bde4d7a9807c04b8756
+size 104190876

--- a/powerbi/Dataset - Azure Data Lake - Sales Performance.pbix
+++ b/powerbi/Dataset - Azure Data Lake - Sales Performance.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:26f8e917a35403002af3c310ea31ca63e74f7b8f0a0ad888b02d0a6f25a3bd31
-size 59041083
+oid sha256:332fbc5690794ffe6b5cc5eba2bd331cfc5a8d5464a996b685de3fdf307b5eb7
+size 59010460

--- a/powerbi/Management Report.pbix
+++ b/powerbi/Management Report.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3bb759b7fc1dd66d424137a8d5de6089534fe03ea3de0e8fa30bda1f2470f875
+oid sha256:5d6dc0ed262627fff3accf1f57b80d64e910a4886a46f1546b8d86e40d9fb0c7
 size 9896344

--- a/powerbi/Strategy Report.pbix
+++ b/powerbi/Strategy Report.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f6172d4c46674a9fb97fdffa5e71cec29a18beb9bd7b2cf92e32e1c23694e313
-size 7511879
+oid sha256:b15603c09f42b4c10f261f8df07a788e48c4cd3701ede5c333dbac03c5bb4a52
+size 7512057

--- a/powerbi/Tactical Report.pbix
+++ b/powerbi/Tactical Report.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8ff319c0d9e0d11a58e432bda28ae0f210dc96fd517d48c396cde7d5b500ae53
+oid sha256:43624e907a760cbd5938f732f44cc99cd80d4b028526514c6317d90bf4ab91ba
 size 7679530

--- a/powerbi/Utility Box Report.pbix
+++ b/powerbi/Utility Box Report.pbix
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:87d4c90ebbc512a0d8edc8dbfd6c18f37958f679d053213bb801271cdb63e234
-size 7747626
+oid sha256:7d77a32ae56996b201b9b6294f305a15cff7f9288953aa7cb0936165be80a88e
+size 7748025

--- a/powerbi/src/Dataset - Azure Data Lake - Automatic Data Enhancement.SemanticModel/definition/tables/report_versions.tmdl
+++ b/powerbi/src/Dataset - Azure Data Lake - Automatic Data Enhancement.SemanticModel/definition/tables/report_versions.tmdl
@@ -38,8 +38,8 @@ table report_versions
 				let
 				    Source = Table.FromRows(Json.Document(Binary.Decompress(Binary.FromText("i45WMtEz0DM2VtJRMjTSN9U3MjAyVoqNBQA=", BinaryEncoding.Base64), Compression.Deflate)), let _t = ((type nullable text) meta [Serialized.Text = true]) in type table [version = _t, release_date = _t]),
 				    #"Changed Type" = Table.TransformColumnTypes(Source,{{"version", type text}, {"release_date", type date}}),
-				    #"Replaced Value1" = Table.ReplaceValue(#"Changed Type",#date(2023, 12, 5),#date(2026, 07, 22),Replacer.ReplaceValue,{"release_date"}),
-				    #"Replaced Value" = Table.ReplaceValue(#"Replaced Value1","4.0.33","4.3.22",Replacer.ReplaceText,{"version"})
+				    #"Replaced Value1" = Table.ReplaceValue(#"Changed Type",#date(2023, 12, 5),#date(2026, 07, 29),Replacer.ReplaceValue,{"release_date"}),
+				    #"Replaced Value" = Table.ReplaceValue(#"Replaced Value1","4.0.33","4.3.23",Replacer.ReplaceText,{"version"})
 				in
 				    #"Replaced Value"
 

--- a/powerbi/src/Dataset - Azure Data Lake - Sales Performance.Report/definition/report.json
+++ b/powerbi/src/Dataset - Azure Data Lake - Sales Performance.Report/definition/report.json
@@ -50,7 +50,8 @@
           }
         },
         "type": "Categorical",
-        "howCreated": "User"
+        "howCreated": "User",
+        "isLockedInViewMode": true
       }
     ],
     "filterSortOrder": "Custom"

--- a/powerbi/src/Dataset - Azure Data Lake - Sales Performance.SemanticModel/definition/tables/opp_line_items.tmdl
+++ b/powerbi/src/Dataset - Azure Data Lake - Sales Performance.SemanticModel/definition/tables/opp_line_items.tmdl
@@ -245,6 +245,132 @@ table opp_line_items
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
+	/// Calculates total list price before discount for distinct won New Logo opportunities.
+	measure 'meas.pricing_total_list_price_won_new_logo' =
+			
+			VAR WonNewLogoOpportunities =
+			    CALCULATETABLE (
+			        VALUES ( ssr_history[entity_opp_id] ),
+			        KEEPFILTERS (
+			            ssr_history[step_name] = "New Logo Selling"
+			        ),
+			        KEEPFILTERS (
+			            ssr_history[step_success] = TRUE ()
+			        ),
+			        KEEPFILTERS (
+			            FILTER (
+			                VALUES ( ssr_history[entity_opp_id] ),
+			                NOT ISBLANK ( ssr_history[entity_opp_id] )
+			            )
+			        )
+			    )
+			
+			RETURN
+			    CALCULATE (
+			        [meas.opp_line_item_total_price_before_discount],
+			        TREATAS (
+			            WonNewLogoOpportunities,
+			            opp_line_items[crm_opp_id]
+			        )
+			    )
+		formatString: \$#,0;(\$#,0);\$#,0
+		displayFolder: _pricing_analysis\New Logo
+		lineageTag: 19b8200e-3227-4908-8b4d-4ab938b3701c
+
+		annotation PBI_FormatHint = {"currencyCulture":"en-US"}
+
+	/// Calculates total final price after discount for distinct won New Logo opportunities.
+	measure 'meas.pricing_total_final_price_won_new_logo' =
+			
+			VAR WonNewLogoOpportunities =
+			    CALCULATETABLE (
+			        VALUES ( ssr_history[entity_opp_id] ),
+			        KEEPFILTERS (
+			            ssr_history[step_name] = "New Logo Selling"
+			        ),
+			        KEEPFILTERS (
+			            ssr_history[step_success] = TRUE ()
+			        ),
+			        KEEPFILTERS (
+			            FILTER (
+			                VALUES ( ssr_history[entity_opp_id] ),
+			                NOT ISBLANK ( ssr_history[entity_opp_id] )
+			            )
+			        )
+			    )
+			
+			RETURN
+			    CALCULATE (
+			        [meas.opp_line_items_trueai_total_price],
+			        TREATAS (
+			            WonNewLogoOpportunities,
+			            opp_line_items[crm_opp_id]
+			        )
+			    )
+		formatString: \$#,0;(\$#,0);\$#,0
+		displayFolder: _pricing_analysis\New Logo
+		lineageTag: 0d524ccd-c9d7-4754-acf8-76cf7e74606a
+
+		annotation PBI_FormatHint = {"currencyCulture":"en-US"}
+
+	/// Calculates average list price before discount per distinct won New Logo opportunity.
+	measure 'meas.pricing_avg_list_price_per_won_new_logo_deal' =
+			
+			DIVIDE (
+			    [meas.pricing_total_list_price_won_new_logo],
+			    ssr_history[meas.pricing_won_new_logo_deals]
+			)
+		formatString: \$#,0;(\$#,0);\$#,0
+		displayFolder: _pricing_analysis\New Logo
+		lineageTag: 882dc1c9-084b-4d28-bb8f-4d5834a394dc
+
+		annotation PBI_FormatHint = {"currencyCulture":"en-US"}
+
+	/// Calculates average final price after discount per distinct won New Logo opportunity.
+	measure 'meas.pricing_avg_final_price_per_won_new_logo_deal' =
+			
+			DIVIDE (
+			    [meas.pricing_total_final_price_won_new_logo],
+			    ssr_history[meas.pricing_won_new_logo_deals]
+			)
+		formatString: \$#,0;(\$#,0);\$#,0
+		displayFolder: _pricing_analysis\New Logo
+		lineageTag: 24eef0a1-f2d8-43b4-b9c2-db8a398ae1ed
+
+		annotation PBI_FormatHint = {"currencyCulture":"en-US"}
+
+	/// Calculates net discount percentage for distinct won New Logo opportunities.
+	measure 'meas.pricing_net_discount_pct_won_new_logo' =
+			
+			VAR WonNewLogoOpportunities =
+			    CALCULATETABLE (
+			        VALUES ( ssr_history[entity_opp_id] ),
+			        KEEPFILTERS (
+			            ssr_history[step_name] = "New Logo Selling"
+			        ),
+			        KEEPFILTERS (
+			            ssr_history[step_success] = TRUE ()
+			        ),
+			        KEEPFILTERS (
+			            FILTER (
+			                VALUES ( ssr_history[entity_opp_id] ),
+			                NOT ISBLANK ( ssr_history[entity_opp_id] )
+			            )
+			        )
+			    )
+			
+			RETURN
+			    CALCULATE (
+			        [meas.opp_line_item_discount_pct],
+			        TREATAS (
+			            WonNewLogoOpportunities,
+			            opp_line_items[crm_opp_id]
+			        )
+			    )
+		formatString: 0.0%;-0.0%;0.0%
+		displayFolder: _pricing_analysis\New Logo
+		lineageTag: 4a47105c-d2a2-4438-8b85-cc59b6350d39
+
 	/// Unique record identifier, based on the ID of the document in the remote system (such as Salesforce ID)
 	column _sys_doc_id
 		dataType: string

--- a/powerbi/src/Dataset - Azure Data Lake - Sales Performance.SemanticModel/definition/tables/report_versions.tmdl
+++ b/powerbi/src/Dataset - Azure Data Lake - Sales Performance.SemanticModel/definition/tables/report_versions.tmdl
@@ -38,8 +38,8 @@ table report_versions
 				let
 				    Source = Table.FromRows(Json.Document(Binary.Decompress(Binary.FromText("i45WMtEz0DM2VtJRMjTSN9U3MjAyVoqNBQA=", BinaryEncoding.Base64), Compression.Deflate)), let _t = ((type nullable text) meta [Serialized.Text = true]) in type table [version = _t, release_date = _t]),
 				    #"Changed Type" = Table.TransformColumnTypes(Source,{{"version", type text}, {"release_date", type date}}),
-				    #"Replaced Value" = Table.ReplaceValue(#"Changed Type","4.0.33","4.3.22",Replacer.ReplaceText,{"version"}),
-				    #"Replaced Value1" = Table.ReplaceValue(#"Replaced Value",#date(2023, 12, 5),#date(2025, 07, 22),Replacer.ReplaceValue,{"release_date"})
+				    #"Replaced Value" = Table.ReplaceValue(#"Changed Type","4.0.33","4.3.23",Replacer.ReplaceText,{"version"}),
+				    #"Replaced Value1" = Table.ReplaceValue(#"Replaced Value",#date(2023, 12, 5),#date(2025, 07, 29),Replacer.ReplaceValue,{"release_date"})
 				in
 				    #"Replaced Value1"
 

--- a/powerbi/src/Dataset - Azure Data Lake - Sales Performance.SemanticModel/definition/tables/ssr_history.tmdl
+++ b/powerbi/src/Dataset - Azure Data Lake - Sales Performance.SemanticModel/definition/tables/ssr_history.tmdl
@@ -13260,6 +13260,28 @@ table ssr_history
 		displayFolder: all_activity_opp
 		lineageTag: 7f2d621f-6f24-44c9-bfe2-d85d7ea6a7ff
 
+	/// Counts distinct nonblank opportunities won in the New Logo Selling step.
+	measure 'meas.pricing_won_new_logo_deals' =
+			
+			CALCULATE (
+			    DISTINCTCOUNT ( ssr_history[entity_opp_id] ),
+			    KEEPFILTERS (
+			        ssr_history[step_name] = "New Logo Selling"
+			    ),
+			    KEEPFILTERS (
+			        ssr_history[step_success] = TRUE ()
+			    ),
+			    KEEPFILTERS (
+			        FILTER (
+			            VALUES ( ssr_history[entity_opp_id] ),
+			            NOT ISBLANK ( ssr_history[entity_opp_id] )
+			        )
+			    )
+			)
+		formatString: #,0
+		displayFolder: _pricing_analysis\New Logo
+		lineageTag: 081f544e-bb19-415e-9a94-294ca6aebc41
+
 	/// Id of the SSR document the record belongs to
 	column _sys_ssr_id
 		dataType: string

--- a/powerbi/src/Dataset - Azure Data Lake - Sales Performance.SemanticModel/definition/tables/users_history.tmdl
+++ b/powerbi/src/Dataset - Azure Data Lake - Sales Performance.SemanticModel/definition/tables/users_history.tmdl
@@ -3012,6 +3012,238 @@ table users_history
 
 		annotation PBI_FormatHint = {"isGeneralNumber":true}
 
+	/// Calculates annualized average bookings per ramped rep in the current role and date context.
+	measure 'meas.org_capacity_aab_ramped' =
+			
+			CALCULATE (
+			    AVERAGE ( users_history[ci_perf_qtly_bookings_user] ) * 4,
+			    KEEPFILTERS (
+			        users_history[col.ci.perf_ramping_status] = "Ramped"
+			    )
+			)
+		formatString: \$#,0;(\$#,0);\$#,0
+		displayFolder: _org_capacity\Benchmarks
+		lineageTag: ae5fda32-11e8-4056-bea6-9b916349c070
+
+		annotation PBI_FormatHint = {"currencyCulture":"en-US"}
+
+	/// Calculates annualized average pipeline created per ramped rep in the current role and date context.
+	measure 'meas.org_capacity_aapc_ramped' =
+			
+			CALCULATE (
+			    AVERAGE ( users_history[ci_perf_qtly_pipeline_user] ) * 4,
+			    KEEPFILTERS (
+			        users_history[col.ci.perf_ramping_status] = "Ramped"
+			    )
+			)
+		formatString: \$#,0;(\$#,0);\$#,0
+		displayFolder: _org_capacity\Benchmarks
+		lineageTag: 90e8baae-5ef2-4604-9e67-39ca16873b13
+
+		annotation PBI_FormatHint = {"currencyCulture":"en-US"}
+
+	/// Returns AAPC for SDR roles and AAB for AE or AM roles. Returns blank for mixed or unsupported roles.
+	measure 'meas.org_capacity_aab_aapc_ramped' =
+			
+			VAR RoleFunction =
+			    SELECTEDVALUE ( users[trueai_user_role_function] )
+			
+			RETURN
+			    SWITCH (
+			        RoleFunction,
+			        "SDR", [meas.org_capacity_aapc_ramped],
+			        "AE",  [meas.org_capacity_aab_ramped],
+			        "AM",  [meas.org_capacity_aab_ramped],
+			        BLANK ()
+			    )
+		formatString: \$#,0;(\$#,0);\$#,0
+		displayFolder: _org_capacity\Benchmarks
+		lineageTag: 6dfc7fca-bcd2-4973-855d-1eb54baea0dc
+
+		annotation PBI_FormatHint = {"currencyCulture":"en-US"}
+
+	/// Returns the role-aware ramped AAB or AAPC for the selected date range shifted back 12 months.
+	measure 'meas.org_capacity_aab_aapc_ramped_py' =
+			
+			VAR CurrentStartDate =
+			    MIN ( cal_end_dates[Date] )
+			
+			VAR CurrentEndDate =
+			    MAX ( cal_end_dates[Date] )
+			
+			VAR PriorDateFilter =
+			    FILTER (
+			        ALL ( cal_end_dates[Date] ),
+			        cal_end_dates[Date] >= EDATE ( CurrentStartDate, -12 )
+			            && cal_end_dates[Date] <= EDATE ( CurrentEndDate, -12 )
+			    )
+			
+			RETURN
+			    CALCULATE (
+			        [meas.org_capacity_aab_aapc_ramped],
+			        REMOVEFILTERS ( cal_end_dates[Date] ),
+			        PriorDateFilter
+			    )
+		formatString: \$#,0;(\$#,0);\$#,0
+		displayFolder: _org_capacity\Prior Period
+		lineageTag: 537f53d4-8481-4ab0-8b57-68c5eb1dfffe
+
+		annotation PBI_FormatHint = {"currencyCulture":"en-US"}
+
+	/// Calculates year-over-year change in the role-aware ramped AAB or AAPC.
+	measure 'meas.org_capacity_aab_aapc_ramped_yoy_pct' =
+			
+			VAR CurrentValue =
+			    [meas.org_capacity_aab_aapc_ramped]
+			
+			VAR PriorValue =
+			    [meas.org_capacity_aab_aapc_ramped_py]
+			
+			RETURN
+			    DIVIDE (
+			        CurrentValue - PriorValue,
+			        PriorValue
+			    )
+		formatString: 0.0%;-0.0%;0.0%
+		displayFolder: _org_capacity\YoY
+		lineageTag: 4698d889-fa7c-4109-81f1-ffa325262ea0
+
+	/// Returns generated pipeline for SDR roles and won bookings for AE or AM roles.
+	measure 'meas.org_capacity_role_production_volume' =
+			
+			VAR RoleFunction =
+			    SELECTEDVALUE ( users[trueai_user_role_function] )
+			
+			VAR SDRPipeline =
+			    CALCULATE (
+			        ssr_history[meas.ssr_history_generated_pipeline_amt],
+			        KEEPFILTERS (
+			            TREATAS (
+			                {
+			                    "Prospecting",
+			                    "Post-Sales Support"
+			                },
+			                ssr_history[step_name]
+			            )
+			        )
+			    )
+			
+			VAR AEAMBookings =
+			    CALCULATE (
+			        ssr_history[meas.ssr_history_won_amt],
+			        KEEPFILTERS (
+			            TREATAS (
+			                {
+			                    "New Logo Selling",
+			                    "Existing Customer Selling",
+			                    "Existing Cust. Selling"
+			                },
+			                ssr_history[step_name]
+			            )
+			        )
+			    )
+			
+			RETURN
+			    SWITCH (
+			        RoleFunction,
+			        "SDR", SDRPipeline,
+			        "AE",  AEAMBookings,
+			        "AM",  AEAMBookings,
+			        BLANK ()
+			    )
+		formatString: \$#,0;(\$#,0);\$#,0
+		displayFolder: _org_capacity\Production
+		lineageTag: 0476b08d-bf2e-4932-bd05-9e4ca31d7e34
+
+		annotation PBI_FormatHint = {"currencyCulture":"en-US"}
+
+	/// Returns role-aware production volume for the selected date range shifted back 12 months.
+	measure 'meas.org_capacity_role_production_volume_py' =
+			
+			VAR CurrentStartDate =
+			    MIN ( cal_end_dates[Date] )
+			
+			VAR CurrentEndDate =
+			    MAX ( cal_end_dates[Date] )
+			
+			VAR PriorDateFilter =
+			    FILTER (
+			        ALL ( cal_end_dates[Date] ),
+			        cal_end_dates[Date] >= EDATE ( CurrentStartDate, -12 )
+			            && cal_end_dates[Date] <= EDATE ( CurrentEndDate, -12 )
+			    )
+			
+			RETURN
+			    CALCULATE (
+			        [meas.org_capacity_role_production_volume],
+			        REMOVEFILTERS ( cal_end_dates[Date] ),
+			        PriorDateFilter
+			    )
+		formatString: \$#,0;(\$#,0);\$#,0
+		displayFolder: _org_capacity\Prior Period
+		lineageTag: 2cd7cc75-d5a6-4415-b264-4a9baeeac0fa
+
+		annotation PBI_FormatHint = {"currencyCulture":"en-US"}
+
+	/// Calculates role-aware production volume per end-of-period rep, including ramped and non-ramped reps.
+	measure 'meas.org_capacity_production_per_eop_rep' =
+			
+			DIVIDE (
+			    [meas.org_capacity_role_production_volume],
+			    [meas.data_logs_user_count_rep_eop]
+			)
+		formatString: \$#,0;(\$#,0);\$#,0
+		displayFolder: _org_capacity\Production
+		lineageTag: baba91dc-1334-457a-abeb-74f836be95ec
+
+		annotation PBI_FormatHint = {"currencyCulture":"en-US"}
+
+	/// Returns production per end-of-period rep for the selected date range shifted back 12 months.
+	measure 'meas.org_capacity_production_per_eop_rep_py' =
+			
+			VAR CurrentStartDate =
+			    MIN ( cal_end_dates[Date] )
+			
+			VAR CurrentEndDate =
+			    MAX ( cal_end_dates[Date] )
+			
+			VAR PriorDateFilter =
+			    FILTER (
+			        ALL ( cal_end_dates[Date] ),
+			        cal_end_dates[Date] >= EDATE ( CurrentStartDate, -12 )
+			            && cal_end_dates[Date] <= EDATE ( CurrentEndDate, -12 )
+			    )
+			
+			RETURN
+			    CALCULATE (
+			        [meas.org_capacity_production_per_eop_rep],
+			        REMOVEFILTERS ( cal_end_dates[Date] ),
+			        PriorDateFilter
+			    )
+		formatString: \$#,0;(\$#,0);\$#,0
+		displayFolder: _org_capacity\Prior Period
+		lineageTag: 5a28256c-97ae-4fcb-9c0f-4e509544394c
+
+		annotation PBI_FormatHint = {"currencyCulture":"en-US"}
+
+	/// Calculates year-over-year change in role-aware production per end-of-period rep.
+	measure 'meas.org_capacity_production_per_eop_rep_yoy_pct' =
+			
+			VAR CurrentValue =
+			    [meas.org_capacity_production_per_eop_rep]
+			
+			VAR PriorValue =
+			    [meas.org_capacity_production_per_eop_rep_py]
+			
+			RETURN
+			    DIVIDE (
+			        CurrentValue - PriorValue,
+			        PriorValue
+			    )
+		formatString: 0.0%;-0.0%;0.0%
+		displayFolder: _org_capacity\YoY
+		lineageTag: e608dde9-da16-4da8-900e-3582c2b8dc7b
+
 	/// Column 'col.ci.perf_qtly_bookings_user' = ```.
 	column 'col.ci.perf_qtly_bookings_user' = ```
 			

--- a/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/95bc3d7a1077f77ad620/visual.json
+++ b/powerbi/src/Strategy Report.Report/definition/pages/ReportSection2c203df1d6a969d001c9/visuals/95bc3d7a1077f77ad620/visual.json
@@ -168,7 +168,7 @@
             "end": {
               "expr": {
                 "Literal": {
-                  "Value": "0.5D"
+                  "Value": "1D"
                 }
               }
             }
@@ -432,6 +432,84 @@
             }
           ]
         }
+      },
+      {
+        "name": "5a014db906149598bdbc",
+        "field": {
+          "HierarchyLevel": {
+            "Expression": {
+              "Hierarchy": {
+                "Expression": {
+                  "PropertyVariationSource": {
+                    "Expression": {
+                      "SourceRef": {
+                        "Entity": "cal_end_dates"
+                      }
+                    },
+                    "Name": "Variación",
+                    "Property": "Fiscal Date"
+                  }
+                },
+                "Hierarchy": "Date Hierarchy"
+              }
+            },
+            "Level": "Year"
+          }
+        },
+        "type": "Advanced"
+      },
+      {
+        "name": "5748d20c10003a2798e0",
+        "field": {
+          "HierarchyLevel": {
+            "Expression": {
+              "Hierarchy": {
+                "Expression": {
+                  "PropertyVariationSource": {
+                    "Expression": {
+                      "SourceRef": {
+                        "Entity": "cal_end_dates"
+                      }
+                    },
+                    "Name": "Variación",
+                    "Property": "Fiscal Date"
+                  }
+                },
+                "Hierarchy": "Date Hierarchy"
+              }
+            },
+            "Level": "Quarter"
+          }
+        },
+        "type": "Categorical"
+      },
+      {
+        "name": "e07389348b007d0b9ce3",
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "users"
+              }
+            },
+            "Property": "trueai_user_role_department"
+          }
+        },
+        "type": "Categorical"
+      },
+      {
+        "name": "9e08ed9050b11c2d53d0",
+        "field": {
+          "Measure": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "ssr_history"
+              }
+            },
+            "Property": "meas.ssr_history_leads_probability_of_conversion_w_thresh"
+          }
+        },
+        "type": "Advanced"
       }
     ]
   }


### PR DESCRIPTION
## What changed

- Added New Logo pricing measures for won-deal counts, list and final prices, average deal values, and net discount.
- Added role-aware organizational-capacity benchmarks, production measures, prior-year comparisons, and YoY calculations.
- Updated Sales Performance and Strategy report configuration and visual filters.
- Bumped report versions and refreshed the related Git LFS-tracked PBIX artifacts.

## Why

Expose pricing analysis and organizational-capacity insights in the canonical semantic models and keep shipped report artifacts aligned with their editable Power BI project sources.

## Impact

Report consumers gain New Logo pricing metrics and role-aware capacity/production comparisons. The Sales Performance filter is locked in view mode, and the Strategy visual receives its updated bounds and filter fields.

## Validation

- Parsed both changed report JSON files successfully.
- Verified all changed PBIX files remain tracked by Git LFS.
- Reviewed the staged diff and excluded the local `.cleanwork/` investigation artifact.
- `git diff --check` reports Power BI-generated CRLF/trailing-whitespace formatting; no source normalization was applied to avoid rewriting generated project files.